### PR TITLE
Multi-language support + 5 new languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ npm run build
 
 - [TW Icon Game](https://github.com/WeiChiaChang/twicon-game)
 - [PokemonDB](https://pokemondb.net/sprites)
+- [International Names](https://pokefans.net/pokedex/pokemon-liste/internationale-namen)
 - [Easter Egg Collection](https://github.com/WeiChiaChang/easter-egg-collection)
+
+## Changelog
+*2020-02-14* Added support for additional languages de, fr, ko, ja, zh  by [@danielstieber](@danielstieber)
 
 > Official Pokémon artwork and sprites are not our creations and are used under a Fair Use Policy, so you are free to use them however you like. Each of the Pokémon sprites pages has an easy way to add images to your site or forum post.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokemon-master",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "start": "serve -s dist/",

--- a/src/components/GuessingButtons.vue
+++ b/src/components/GuessingButtons.vue
@@ -10,11 +10,13 @@
         'correct': justGuessed && correctFlag.code === flag.code,
         'wrong': justGuessed && currentGuess === flag.code && correctFlag.code !== flag.code,
       }"
-    >{{flag.name}}</md-button>
+    >{{flag[currentLanguage]}}</md-button>
   </md-content>
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
 export default {
   // Component name
   name: 'GuessingButtons',
@@ -32,6 +34,11 @@ export default {
     onClick(code) {
       this.$emit('guess', code);
     },
+  },
+  computed: {
+    ...mapState({
+      currentLanguage: ({ currentLanguage }) => currentLanguage,
+    }),
   },
 };
 </script>

--- a/src/components/Score.vue
+++ b/src/components/Score.vue
@@ -22,7 +22,7 @@ export default {
       return '0.00';
     },
     ...mapState({
-      score: ({ score }) => score,
+      score: ({ score }) => score
     }),
   },
 };

--- a/src/components/Score.vue
+++ b/src/components/Score.vue
@@ -22,7 +22,7 @@ export default {
       return '0.00';
     },
     ...mapState({
-      score: ({ score }) => score
+      score: ({ score }) => score,
     }),
   },
 };

--- a/src/components/SelectLanguage.vue
+++ b/src/components/SelectLanguage.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <button
+      @click="language('en')"
+      class="nes-btn"
+      v-bind:class="{ 'is-warning': currentLanguage == 'en' }"
+    >en</button>
+    <button @click="language('de')"
+      class="nes-btn"
+      v-bind:class="{ 'is-warning': currentLanguage == 'de' }"
+    >de</button>
+    <button @click="language('fr')"
+      class="nes-btn"
+      v-bind:class="{ 'is-warning': currentLanguage == 'fr' }"
+    >fr</button>
+    <button @click="language('ja')"
+      class="nes-btn"
+      v-bind:class="{ 'is-warning': currentLanguage == 'ja' }"
+    >ja</button>
+    <button @click="language('ko')"
+      class="nes-btn"
+      v-bind:class="{ 'is-warning': currentLanguage == 'ko' }"
+    >ko</button>
+    <button @click="language('zh')"
+      class="nes-btn"
+      v-bind:class="{ 'is-warning': currentLanguage == 'zh' }"
+    >zh</button>
+  </div>
+</template>
+
+
+<script>
+import { mapActions, mapState } from 'vuex';
+
+export default {
+  // Component name
+  name: 'SelectLanguage',
+  methods: {
+    ...mapActions(['setLanguage']),
+    language: function(language) {
+      // set the language
+      this.setLanguage(language);
+    },
+  },
+  computed: {
+    ...mapState({
+      currentLanguage: ({ currentLanguage }) => currentLanguage,
+    }),
+  },
+};
+</script>

--- a/src/constants/flags.js
+++ b/src/constants/flags.js
@@ -1,4857 +1,8902 @@
 // 809 pokemons
 export default [
-  {
-    "code": "Bulbasaur",
-    "name": "Bulbasaur",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bulbasaur.png",
-    "obs_code": "pokemon_3655199784"
-  },
-  {
-    "code": "Ivysaur",
-    "name": "Ivysaur",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ivysaur.png",
-    "obs_code": "pokemon_756643862"
-  },
-  {
-    "code": "Venusaur",
-    "name": "Venusaur",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/venusaur.png",
-    "obs_code": "pokemon_3494250168"
-  },
-  {
-    "code": "Charmander",
-    "name": "Charmander",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/charmander.png",
-    "obs_code": "pokemon_2163171052"
-  },
-  {
-    "code": "Charmeleon",
-    "name": "Charmeleon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/charmeleon.png",
-    "obs_code": "pokemon_2322275101"
-  },
-  {
-    "code": "Charizard",
-    "name": "Charizard",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/charizard.png",
-    "obs_code": "pokemon_678975897"
-  },
-  {
-    "code": "Squirtle",
-    "name": "Squirtle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/squirtle.png",
-    "obs_code": "pokemon_3326135028"
-  },
-  {
-    "code": "Wartortle",
-    "name": "Wartortle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wartortle.png",
-    "obs_code": "pokemon_2394918325"
-  },
-  {
-    "code": "Blastoise",
-    "name": "Blastoise",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/blastoise.png",
-    "obs_code": "pokemon_1803009917"
-  },
-  {
-    "code": "Caterpie",
-    "name": "Caterpie",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/caterpie.png",
-    "obs_code": "pokemon_1405970488"
-  },
-  {
-    "code": "Metapod",
-    "name": "Metapod",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/metapod.png",
-    "obs_code": "pokemon_2888465571"
-  },
-  {
-    "code": "Butterfree",
-    "name": "Butterfree",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/butterfree.png",
-    "obs_code": "pokemon_991322385"
-  },
-  {
-    "code": "Weedle",
-    "name": "Weedle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/weedle.png",
-    "obs_code": "pokemon_1165969119"
-  },
-  {
-    "code": "Kakuna",
-    "name": "Kakuna",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kakuna.png",
-    "obs_code": "pokemon_1311611006"
-  },
-  {
-    "code": "Beedrill",
-    "name": "Beedrill",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/beedrill.png",
-    "obs_code": "pokemon_4244249304"
-  },
-  {
-    "code": "Pidgey",
-    "name": "Pidgey",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pidgey.png",
-    "obs_code": "pokemon_2241915235"
-  },
-  {
-    "code": "Pidgeotto",
-    "name": "Pidgeotto",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pidgeotto.png",
-    "obs_code": "pokemon_1277809466"
-  },
-  {
-    "code": "Pidgeot",
-    "name": "Pidgeot",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pidgeot.png",
-    "obs_code": "pokemon_2061507553"
-  },
-  {
-    "code": "Rattata",
-    "name": "Rattata",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rattata.png",
-    "obs_code": "pokemon_696281826"
-  },
-  {
-    "code": "Raticate",
-    "name": "Raticate",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/raticate.png",
-    "obs_code": "pokemon_287419288"
-  },
-  {
-    "code": "Spearow",
-    "name": "Spearow",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spearow.png",
-    "obs_code": "pokemon_2332841864"
-  },
-  {
-    "code": "Fearow",
-    "name": "Fearow",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fearow.png",
-    "obs_code": "pokemon_2022950029"
-  },
-  {
-    "code": "Ekans",
-    "name": "Ekans",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ekans.png",
-    "obs_code": "pokemon_195681655"
-  },
-  {
-    "code": "Arbok",
-    "name": "Arbok",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/arbok.png",
-    "obs_code": "pokemon_185863856"
-  },
-  {
-    "code": "Pikachu",
-    "name": "Pikachu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pikachu.png",
-    "obs_code": "pokemon_3159874312"
-  },
-  {
-    "code": "Raichu",
-    "name": "Raichu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/raichu.png",
-    "obs_code": "pokemon_1787702049"
-  },
-  {
-    "code": "Sandshrew",
-    "name": "Sandshrew",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sandshrew.png",
-    "obs_code": "pokemon_1607652486"
-  },
-  {
-    "code": "Sandslash",
-    "name": "Sandslash",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sandslash.png",
-    "obs_code": "pokemon_2874792856"
-  },
-  {
-    "code": "Nidoran♀",
-    "name": "Nidoran♀",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidoran-f.png",
-    "obs_code": "pokemon_2845635167"
-  },
-  {
-    "code": "Nidorina",
-    "name": "Nidorina",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidorina.png",
-    "obs_code": "pokemon_1347218269"
-  },
-  {
-    "code": "Nidoqueen",
-    "name": "Nidoqueen",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidoqueen.png",
-    "obs_code": "pokemon_1511427523"
-  },
-  {
-    "code": "Nidoran♂",
-    "name": "Nidoran♂",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidoran-m.png",
-    "obs_code": "pokemon_4223059540"
-  },
-  {
-    "code": "Nidorino",
-    "name": "Nidorino",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidorino.png",
-    "obs_code": "pokemon_3922806035"
-  },
-  {
-    "code": "Nidoking",
-    "name": "Nidoking",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidoking.png",
-    "obs_code": "pokemon_832003330"
-  },
-  {
-    "code": "Clefairy",
-    "name": "Clefairy",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/clefairy.png",
-    "obs_code": "pokemon_1907242314"
-  },
-  {
-    "code": "Clefable",
-    "name": "Clefable",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/clefable.png",
-    "obs_code": "pokemon_3106758051"
-  },
-  {
-    "code": "Vulpix",
-    "name": "Vulpix",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vulpix.png",
-    "obs_code": "pokemon_2201895275"
-  },
-  {
-    "code": "Ninetales",
-    "name": "Ninetales",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ninetales.png",
-    "obs_code": "pokemon_3975518150"
-  },
-  {
-    "code": "Jigglypuff",
-    "name": "Jigglypuff",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jigglypuff.png",
-    "obs_code": "pokemon_535745110"
-  },
-  {
-    "code": "Wigglytuff",
-    "name": "Wigglytuff",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wigglytuff.png",
-    "obs_code": "pokemon_1397441103"
-  },
-  {
-    "code": "Zubat",
-    "name": "Zubat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zubat.png",
-    "obs_code": "pokemon_182954333"
-  },
-  {
-    "code": "Golbat",
-    "name": "Golbat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golbat.png",
-    "obs_code": "pokemon_1742551798"
-  },
-  {
-    "code": "Oddish",
-    "name": "Oddish",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/oddish.png",
-    "obs_code": "pokemon_1602482040"
-  },
-  {
-    "code": "Gloom",
-    "name": "Gloom",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gloom.png",
-    "obs_code": "pokemon_174575971"
-  },
-  {
-    "code": "Vileplume",
-    "name": "Vileplume",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vileplume.png",
-    "obs_code": "pokemon_2681015090"
-  },
-  {
-    "code": "Paras",
-    "name": "Paras",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/paras.png",
-    "obs_code": "pokemon_195692756"
-  },
-  {
-    "code": "Parasect",
-    "name": "Parasect",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/parasect.png",
-    "obs_code": "pokemon_1282026470"
-  },
-  {
-    "code": "Venonat",
-    "name": "Venonat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/venonat.png",
-    "obs_code": "pokemon_1682780716"
-  },
-  {
-    "code": "Venomoth",
-    "name": "Venomoth",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/venomoth.png",
-    "obs_code": "pokemon_1855270569"
-  },
-  {
-    "code": "Diglett",
-    "name": "Diglett",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/diglett.png",
-    "obs_code": "pokemon_1152585702"
-  },
-  {
-    "code": "Dugtrio",
-    "name": "Dugtrio",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dugtrio.png",
-    "obs_code": "pokemon_4062645395"
-  },
-  {
-    "code": "Meowth",
-    "name": "Meowth",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meowth.png",
-    "obs_code": "pokemon_1598702857"
-  },
-  {
-    "code": "Persian",
-    "name": "Persian",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/persian.png",
-    "obs_code": "pokemon_3212116151"
-  },
-  {
-    "code": "Psyduck",
-    "name": "Psyduck",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/psyduck.png",
-    "obs_code": "pokemon_1020034118"
-  },
-  {
-    "code": "Golduck",
-    "name": "Golduck",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golduck.png",
-    "obs_code": "pokemon_1020039576"
-  },
-  {
-    "code": "Mankey",
-    "name": "Mankey",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mankey.png",
-    "obs_code": "pokemon_2241503728"
-  },
-  {
-    "code": "Primeape",
-    "name": "Primeape",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/primeape.png",
-    "obs_code": "pokemon_3718319538"
-  },
-  {
-    "code": "Growlithe",
-    "name": "Growlithe",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/growlithe.png",
-    "obs_code": "pokemon_1524079572"
-  },
-  {
-    "code": "Arcanine",
-    "name": "Arcanine",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/arcanine.png",
-    "obs_code": "pokemon_104116984"
-  },
-  {
-    "code": "Poliwag",
-    "name": "Poliwag",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/poliwag.png",
-    "obs_code": "pokemon_2640456430"
-  },
-  {
-    "code": "Poliwhirl",
-    "name": "Poliwhirl",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/poliwhirl.png",
-    "obs_code": "pokemon_2235994839"
-  },
-  {
-    "code": "Poliwrath",
-    "name": "Poliwrath",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/poliwrath.png",
-    "obs_code": "pokemon_2173645383"
-  },
-  {
-    "code": "Abra",
-    "name": "Abra",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/abra.png",
-    "obs_code": "pokemon_2087569269"
-  },
-  {
-    "code": "Kadabra",
-    "name": "Kadabra",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kadabra.png",
-    "obs_code": "pokemon_783164059"
-  },
-  {
-    "code": "Alakazam",
-    "name": "Alakazam",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/alakazam.png",
-    "obs_code": "pokemon_1239381269"
-  },
-  {
-    "code": "Machop",
-    "name": "Machop",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/machop.png",
-    "obs_code": "pokemon_1901094205"
-  },
-  {
-    "code": "Machoke",
-    "name": "Machoke",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/machoke.png",
-    "obs_code": "pokemon_4148401283"
-  },
-  {
-    "code": "Machamp",
-    "name": "Machamp",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/machamp.png",
-    "obs_code": "pokemon_2697488990"
-  },
-  {
-    "code": "Bellsprout",
-    "name": "Bellsprout",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bellsprout.png",
-    "obs_code": "pokemon_2183703965"
-  },
-  {
-    "code": "Weepinbell",
-    "name": "Weepinbell",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/weepinbell.png",
-    "obs_code": "pokemon_1780103490"
-  },
-  {
-    "code": "Victreebel",
-    "name": "Victreebel",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/victreebel.png",
-    "obs_code": "pokemon_4172198804"
-  },
-  {
-    "code": "Tentacool",
-    "name": "Tentacool",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tentacool.png",
-    "obs_code": "pokemon_4003183136"
-  },
-  {
-    "code": "Tentacruel",
-    "name": "Tentacruel",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tentacruel.png",
-    "obs_code": "pokemon_1722524770"
-  },
-  {
-    "code": "Geodude",
-    "name": "Geodude",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/geodude.png",
-    "obs_code": "pokemon_3822066232"
-  },
-  {
-    "code": "Graveler",
-    "name": "Graveler",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/graveler.png",
-    "obs_code": "pokemon_3170206169"
-  },
-  {
-    "code": "Golem",
-    "name": "Golem",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golem.png",
-    "obs_code": "pokemon_174640521"
-  },
-  {
-    "code": "Ponyta",
-    "name": "Ponyta",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ponyta.png",
-    "obs_code": "pokemon_1322323704"
-  },
-  {
-    "code": "Rapidash",
-    "name": "Rapidash",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rapidash.png",
-    "obs_code": "pokemon_1658606833"
-  },
-  {
-    "code": "Slowpoke",
-    "name": "Slowpoke",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slowpoke.png",
-    "obs_code": "pokemon_3762039859"
-  },
-  {
-    "code": "Slowbro",
-    "name": "Slowbro",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slowbro.png",
-    "obs_code": "pokemon_499346493"
-  },
-  {
-    "code": "Magnemite",
-    "name": "Magnemite",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magnemite.png",
-    "obs_code": "pokemon_2236810000"
-  },
-  {
-    "code": "Magneton",
-    "name": "Magneton",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magneton.png",
-    "obs_code": "pokemon_3853274864"
-  },
-  {
-    "code": "Farfetch'd",
-    "name": "Farfetch'd",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/farfetchd.png",
-    "obs_code": "pokemon_1980596776"
-  },
-  {
-    "code": "Doduo",
-    "name": "Doduo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/doduo.png",
-    "obs_code": "pokemon_182199568"
-  },
-  {
-    "code": "Dodrio",
-    "name": "Dodrio",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dodrio.png",
-    "obs_code": "pokemon_1684934430"
-  },
-  {
-    "code": "Seel",
-    "name": "Seel",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seel.png",
-    "obs_code": "pokemon_2087669242"
-  },
-  {
-    "code": "Dewgong",
-    "name": "Dewgong",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dewgong.png",
-    "obs_code": "pokemon_2881290514"
-  },
-  {
-    "code": "Grimer",
-    "name": "Grimer",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/grimer.png",
-    "obs_code": "pokemon_2124714595"
-  },
-  {
-    "code": "Muk",
-    "name": "Muk",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/muk.png",
-    "obs_code": "pokemon_193425206"
-  },
-  {
-    "code": "Shellder",
-    "name": "Shellder",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shellder.png",
-    "obs_code": "pokemon_2868218568"
-  },
-  {
-    "code": "Cloyster",
-    "name": "Cloyster",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cloyster.png",
-    "obs_code": "pokemon_2248079084"
-  },
-  {
-    "code": "Gastly",
-    "name": "Gastly",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gastly.png",
-    "obs_code": "pokemon_2233030097"
-  },
-  {
-    "code": "Haunter",
-    "name": "Haunter",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/haunter.png",
-    "obs_code": "pokemon_1369260116"
-  },
-  {
-    "code": "Gengar",
-    "name": "Gengar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gengar.png",
-    "obs_code": "pokemon_2128978205"
-  },
-  {
-    "code": "Onix",
-    "name": "Onix",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/onix.png",
-    "obs_code": "pokemon_2088375125"
-  },
-  {
-    "code": "Drowzee",
-    "name": "Drowzee",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drowzee.png",
-    "obs_code": "pokemon_3806497361"
-  },
-  {
-    "code": "Hypno",
-    "name": "Hypno",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hypno.png",
-    "obs_code": "pokemon_181181541"
-  },
-  {
-    "code": "Krabby",
-    "name": "Krabby",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/krabby.png",
-    "obs_code": "pokemon_2245511716"
-  },
-  {
-    "code": "Kingler",
-    "name": "Kingler",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kingler.png",
-    "obs_code": "pokemon_1397374005"
-  },
-  {
-    "code": "Voltorb",
-    "name": "Voltorb",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/voltorb.png",
-    "obs_code": "pokemon_2713737019"
-  },
-  {
-    "code": "Electrode",
-    "name": "Electrode",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/electrode.png",
-    "obs_code": "pokemon_2179400930"
-  },
-  {
-    "code": "Exeggcute",
-    "name": "Exeggcute",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/exeggcute.png",
-    "obs_code": "pokemon_824178842"
-  },
-  {
-    "code": "Exeggutor",
-    "name": "Exeggutor",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/exeggutor.png",
-    "obs_code": "pokemon_1314473633"
-  },
-  {
-    "code": "Cubone",
-    "name": "Cubone",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cubone.png",
-    "obs_code": "pokemon_1163486965"
-  },
-  {
-    "code": "Marowak",
-    "name": "Marowak",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/marowak.png",
-    "obs_code": "pokemon_948484329"
-  },
-  {
-    "code": "Hitmonlee",
-    "name": "Hitmonlee",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hitmonlee.png",
-    "obs_code": "pokemon_2621613808"
-  },
-  {
-    "code": "Hitmonchan",
-    "name": "Hitmonchan",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hitmonchan.png",
-    "obs_code": "pokemon_2891815448"
-  },
-  {
-    "code": "Lickitung",
-    "name": "Lickitung",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lickitung.png",
-    "obs_code": "pokemon_701170825"
-  },
-  {
-    "code": "Koffing",
-    "name": "Koffing",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/koffing.png",
-    "obs_code": "pokemon_2888068641"
-  },
-  {
-    "code": "Weezing",
-    "name": "Weezing",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/weezing.png",
-    "obs_code": "pokemon_2889073576"
-  },
-  {
-    "code": "Rhyhorn",
-    "name": "Rhyhorn",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rhyhorn.png",
-    "obs_code": "pokemon_3575858717"
-  },
-  {
-    "code": "Rhydon",
-    "name": "Rhydon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rhydon.png",
-    "obs_code": "pokemon_1647614147"
-  },
-  {
-    "code": "Chansey",
-    "name": "Chansey",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chansey.png",
-    "obs_code": "pokemon_945117422"
-  },
-  {
-    "code": "Tangela",
-    "name": "Tangela",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tangela.png",
-    "obs_code": "pokemon_388180625"
-  },
-  {
-    "code": "Kangaskhan",
-    "name": "Kangaskhan",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kangaskhan.png",
-    "obs_code": "pokemon_550269176"
-  },
-  {
-    "code": "Horsea",
-    "name": "Horsea",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/horsea.png",
-    "obs_code": "pokemon_1303086631"
-  },
-  {
-    "code": "Seadra",
-    "name": "Seadra",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seadra.png",
-    "obs_code": "pokemon_1325026373"
-  },
-  {
-    "code": "Goldeen",
-    "name": "Goldeen",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/goldeen.png",
-    "obs_code": "pokemon_3373145803"
-  },
-  {
-    "code": "Seaking",
-    "name": "Seaking",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seaking.png",
-    "obs_code": "pokemon_2888534297"
-  },
-  {
-    "code": "Staryu",
-    "name": "Staryu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/staryu.png",
-    "obs_code": "pokemon_1768228349"
-  },
-  {
-    "code": "Starmie",
-    "name": "Starmie",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/starmie.png",
-    "obs_code": "pokemon_3925661168"
-  },
-  {
-    "code": "Mr. Mime",
-    "name": "Mr. Mime",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mr-mime.png",
-    "obs_code": "pokemon_4076847003"
-  },
-  {
-    "code": "Scyther",
-    "name": "Scyther",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scyther.png",
-    "obs_code": "pokemon_1392601671"
-  },
-  {
-    "code": "Jynx",
-    "name": "Jynx",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jynx.png",
-    "obs_code": "pokemon_2088367136"
-  },
-  {
-    "code": "Electabuzz",
-    "name": "Electabuzz",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/electabuzz.png",
-    "obs_code": "pokemon_794849320"
-  },
-  {
-    "code": "Magmar",
-    "name": "Magmar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magmar.png",
-    "obs_code": "pokemon_2129186320"
-  },
-  {
-    "code": "Pinsir",
-    "name": "Pinsir",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pinsir.png",
-    "obs_code": "pokemon_2138008602"
-  },
-  {
-    "code": "Tauros",
-    "name": "Tauros",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tauros.png",
-    "obs_code": "pokemon_2170026123"
-  },
-  {
-    "code": "Magikarp",
-    "name": "Magikarp",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magikarp.png",
-    "obs_code": "pokemon_3496369263"
-  },
-  {
-    "code": "Gyarados",
-    "name": "Gyarados",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gyarados.png",
-    "obs_code": "pokemon_1758508625"
-  },
-  {
-    "code": "Lapras",
-    "name": "Lapras",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lapras.png",
-    "obs_code": "pokemon_2162909528"
-  },
-  {
-    "code": "Ditto",
-    "name": "Ditto",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ditto.png",
-    "obs_code": "pokemon_182215975"
-  },
-  {
-    "code": "Eevee",
-    "name": "Eevee",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/eevee.png",
-    "obs_code": "pokemon_165185491"
-  },
-  {
-    "code": "Vaporeon",
-    "name": "Vaporeon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vaporeon.png",
-    "obs_code": "pokemon_3212751227"
-  },
-  {
-    "code": "Jolteon",
-    "name": "Jolteon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jolteon.png",
-    "obs_code": "pokemon_2830446492"
-  },
-  {
-    "code": "Flareon",
-    "name": "Flareon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/flareon.png",
-    "obs_code": "pokemon_2830511352"
-  },
-  {
-    "code": "Porygon",
-    "name": "Porygon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/porygon.png",
-    "obs_code": "pokemon_2837572087"
-  },
-  {
-    "code": "Omanyte",
-    "name": "Omanyte",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/omanyte.png",
-    "obs_code": "pokemon_128893920"
-  },
-  {
-    "code": "Omastar",
-    "name": "Omastar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/omastar.png",
-    "obs_code": "pokemon_1516692594"
-  },
-  {
-    "code": "Kabuto",
-    "name": "Kabuto",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kabuto.png",
-    "obs_code": "pokemon_1718129379"
-  },
-  {
-    "code": "Kabutops",
-    "name": "Kabutops",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kabutops.png",
-    "obs_code": "pokemon_248170752"
-  },
-  {
-    "code": "Aerodactyl",
-    "name": "Aerodactyl",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aerodactyl.png",
-    "obs_code": "pokemon_4053478267"
-  },
-  {
-    "code": "Snorlax",
-    "name": "Snorlax",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/snorlax.png",
-    "obs_code": "pokemon_4260093168"
-  },
-  {
-    "code": "Articuno",
-    "name": "Articuno",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/articuno.png",
-    "obs_code": "pokemon_4062334460"
-  },
-  {
-    "code": "Zapdos",
-    "name": "Zapdos",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zapdos.png",
-    "obs_code": "pokemon_2170780566"
-  },
-  {
-    "code": "Moltres",
-    "name": "Moltres",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/moltres.png",
-    "obs_code": "pokemon_2500142875"
-  },
-  {
-    "code": "Dratini",
-    "name": "Dratini",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dratini.png",
-    "obs_code": "pokemon_1435799752"
-  },
-  {
-    "code": "Dragonair",
-    "name": "Dragonair",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dragonair.png",
-    "obs_code": "pokemon_1852247310"
-  },
-  {
-    "code": "Dragonite",
-    "name": "Dragonite",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dragonite.png",
-    "obs_code": "pokemon_2131004652"
-  },
-  {
-    "code": "Mewtwo",
-    "name": "Mewtwo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mewtwo.png",
-    "obs_code": "pokemon_1719306326"
-  },
-  {
-    "code": "Mew",
-    "name": "Mew",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mew.png",
-    "obs_code": "pokemon_193429306"
-  },
-  {
-    "code": "Chikorita",
-    "name": "Chikorita",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chikorita.png",
-    "obs_code": "pokemon_3833066669"
-  },
-  {
-    "code": "Bayleef",
-    "name": "Bayleef",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bayleef.png",
-    "obs_code": "pokemon_1631646677"
-  },
-  {
-    "code": "Meganium",
-    "name": "Meganium",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meganium.png",
-    "obs_code": "pokemon_489921044"
-  },
-  {
-    "code": "Cyndaquil",
-    "name": "Cyndaquil",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cyndaquil.png",
-    "obs_code": "pokemon_1285047989"
-  },
-  {
-    "code": "Quilava",
-    "name": "Quilava",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/quilava.png",
-    "obs_code": "pokemon_623456498"
-  },
-  {
-    "code": "Typhlosion",
-    "name": "Typhlosion",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/typhlosion.png",
-    "obs_code": "pokemon_2004082920"
-  },
-  {
-    "code": "Totodile",
-    "name": "Totodile",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/totodile.png",
-    "obs_code": "pokemon_2524045185"
-  },
-  {
-    "code": "Croconaw",
-    "name": "Croconaw",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/croconaw.png",
-    "obs_code": "pokemon_4152801167"
-  },
-  {
-    "code": "Feraligatr",
-    "name": "Feraligatr",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/feraligatr.png",
-    "obs_code": "pokemon_3207191952"
-  },
-  {
-    "code": "Sentret",
-    "name": "Sentret",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sentret.png",
-    "obs_code": "pokemon_1807219786"
-  },
-  {
-    "code": "Furret",
-    "name": "Furret",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/furret.png",
-    "obs_code": "pokemon_1746718119"
-  },
-  {
-    "code": "Hoothoot",
-    "name": "Hoothoot",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hoothoot.png",
-    "obs_code": "pokemon_3072252741"
-  },
-  {
-    "code": "Noctowl",
-    "name": "Noctowl",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/noctowl.png",
-    "obs_code": "pokemon_615924295"
-  },
-  {
-    "code": "Ledyba",
-    "name": "Ledyba",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ledyba.png",
-    "obs_code": "pokemon_1307012274"
-  },
-  {
-    "code": "Ledian",
-    "name": "Ledian",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ledian.png",
-    "obs_code": "pokemon_1659135694"
-  },
-  {
-    "code": "Spinarak",
-    "name": "Spinarak",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spinarak.png",
-    "obs_code": "pokemon_1355492472"
-  },
-  {
-    "code": "Ariados",
-    "name": "Ariados",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ariados.png",
-    "obs_code": "pokemon_2916608838"
-  },
-  {
-    "code": "Crobat",
-    "name": "Crobat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/crobat.png",
-    "obs_code": "pokemon_1742544140"
-  },
-  {
-    "code": "Chinchou",
-    "name": "Chinchou",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chinchou.png",
-    "obs_code": "pokemon_3641110264"
-  },
-  {
-    "code": "Lanturn",
-    "name": "Lanturn",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lanturn.png",
-    "obs_code": "pokemon_3568768123"
-  },
-  {
-    "code": "Pichu",
-    "name": "Pichu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pichu.png",
-    "obs_code": "pokemon_184323298"
-  },
-  {
-    "code": "Cleffa",
-    "name": "Cleffa",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cleffa.png",
-    "obs_code": "pokemon_1301658990"
-  },
-  {
-    "code": "Igglybuff",
-    "name": "Igglybuff",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/igglybuff.png",
-    "obs_code": "pokemon_1355257582"
-  },
-  {
-    "code": "Togepi",
-    "name": "Togepi",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/togepi.png",
-    "obs_code": "pokemon_1640303397"
-  },
-  {
-    "code": "Togetic",
-    "name": "Togetic",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/togetic.png",
-    "obs_code": "pokemon_3820741026"
-  },
-  {
-    "code": "Natu",
-    "name": "Natu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/natu.png",
-    "obs_code": "pokemon_2087971979"
-  },
-  {
-    "code": "Xatu",
-    "name": "Xatu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/xatu.png",
-    "obs_code": "pokemon_2087971997"
-  },
-  {
-    "code": "Mareep",
-    "name": "Mareep",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mareep.png",
-    "obs_code": "pokemon_1894494859"
-  },
-  {
-    "code": "Flaaffy",
-    "name": "Flaaffy",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/flaaffy.png",
-    "obs_code": "pokemon_935656822"
-  },
-  {
-    "code": "Ampharos",
-    "name": "Ampharos",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ampharos.png",
-    "obs_code": "pokemon_902499358"
-  },
-  {
-    "code": "Bellossom",
-    "name": "Bellossom",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bellossom.png",
-    "obs_code": "pokemon_744947567"
-  },
-  {
-    "code": "Marill",
-    "name": "Marill",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/marill.png",
-    "obs_code": "pokemon_1423721362"
-  },
-  {
-    "code": "Azumarill",
-    "name": "Azumarill",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/azumarill.png",
-    "obs_code": "pokemon_2624113404"
-  },
-  {
-    "code": "Sudowoodo",
-    "name": "Sudowoodo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sudowoodo.png",
-    "obs_code": "pokemon_87391092"
-  },
-  {
-    "code": "Politoed",
-    "name": "Politoed",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/politoed.png",
-    "obs_code": "pokemon_1268321637"
-  },
-  {
-    "code": "Hoppip",
-    "name": "Hoppip",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hoppip.png",
-    "obs_code": "pokemon_1907798843"
-  },
-  {
-    "code": "Skiploom",
-    "name": "Skiploom",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skiploom.png",
-    "obs_code": "pokemon_3084934757"
-  },
-  {
-    "code": "Jumpluff",
-    "name": "Jumpluff",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jumpluff.png",
-    "obs_code": "pokemon_2781230238"
-  },
-  {
-    "code": "Aipom",
-    "name": "Aipom",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aipom.png",
-    "obs_code": "pokemon_174594591"
-  },
-  {
-    "code": "Sunkern",
-    "name": "Sunkern",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sunkern.png",
-    "obs_code": "pokemon_3587205471"
-  },
-  {
-    "code": "Sunflora",
-    "name": "Sunflora",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sunflora.png",
-    "obs_code": "pokemon_181436603"
-  },
-  {
-    "code": "Yanma",
-    "name": "Yanma",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/yanma.png",
-    "obs_code": "pokemon_169911647"
-  },
-  {
-    "code": "Wooper",
-    "name": "Wooper",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wooper.png",
-    "obs_code": "pokemon_2123764021"
-  },
-  {
-    "code": "Quagsire",
-    "name": "Quagsire",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/quagsire.png",
-    "obs_code": "pokemon_1578860042"
-  },
-  {
-    "code": "Espeon",
-    "name": "Espeon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/espeon.png",
-    "obs_code": "pokemon_1647572359"
-  },
-  {
-    "code": "Umbreon",
-    "name": "Umbreon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/umbreon.png",
-    "obs_code": "pokemon_2830512137"
-  },
-  {
-    "code": "Murkrow",
-    "name": "Murkrow",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/murkrow.png",
-    "obs_code": "pokemon_2332650030"
-  },
-  {
-    "code": "Slowking",
-    "name": "Slowking",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slowking.png",
-    "obs_code": "pokemon_832856169"
-  },
-  {
-    "code": "Misdreavus",
-    "name": "Misdreavus",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/misdreavus.png",
-    "obs_code": "pokemon_1760655216"
-  },
-  {
-    "code": "Unown",
-    "name": "Unown",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/unown.png",
-    "obs_code": "pokemon_180937064"
-  },
-  {
-    "code": "Wobbuffet",
-    "name": "Wobbuffet",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wobbuffet.png",
-    "obs_code": "pokemon_3005062745"
-  },
-  {
-    "code": "Girafarig",
-    "name": "Girafarig",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/girafarig.png",
-    "obs_code": "pokemon_1468473283"
-  },
-  {
-    "code": "Pineco",
-    "name": "Pineco",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pineco.png",
-    "obs_code": "pokemon_1696169979"
-  },
-  {
-    "code": "Forretress",
-    "name": "Forretress",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/forretress.png",
-    "obs_code": "pokemon_125015082"
-  },
-  {
-    "code": "Dunsparce",
-    "name": "Dunsparce",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dunsparce.png",
-    "obs_code": "pokemon_1631287756"
-  },
-  {
-    "code": "Gligar",
-    "name": "Gligar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gligar.png",
-    "obs_code": "pokemon_2128968691"
-  },
-  {
-    "code": "Steelix",
-    "name": "Steelix",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/steelix.png",
-    "obs_code": "pokemon_3966719711"
-  },
-  {
-    "code": "Snubbull",
-    "name": "Snubbull",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/snubbull.png",
-    "obs_code": "pokemon_87043000"
-  },
-  {
-    "code": "Granbull",
-    "name": "Granbull",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/granbull.png",
-    "obs_code": "pokemon_87486632"
-  },
-  {
-    "code": "Qwilfish",
-    "name": "Qwilfish",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/qwilfish.png",
-    "obs_code": "pokemon_1348720274"
-  },
-  {
-    "code": "Scizor",
-    "name": "Scizor",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scizor.png",
-    "obs_code": "pokemon_2125922811"
-  },
-  {
-    "code": "Shuckle",
-    "name": "Shuckle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shuckle.png",
-    "obs_code": "pokemon_4118086058"
-  },
-  {
-    "code": "Heracross",
-    "name": "Heracross",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/heracross.png",
-    "obs_code": "pokemon_4000164773"
-  },
-  {
-    "code": "Sneasel",
-    "name": "Sneasel",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sneasel.png",
-    "obs_code": "pokemon_101555526"
-  },
-  {
-    "code": "Teddiursa",
-    "name": "Teddiursa",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/teddiursa.png",
-    "obs_code": "pokemon_1972940072"
-  },
-  {
-    "code": "Ursaring",
-    "name": "Ursaring",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ursaring.png",
-    "obs_code": "pokemon_840785442"
-  },
-  {
-    "code": "Slugma",
-    "name": "Slugma",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slugma.png",
-    "obs_code": "pokemon_1312169476"
-  },
-  {
-    "code": "Magcargo",
-    "name": "Magcargo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magcargo.png",
-    "obs_code": "pokemon_1834930998"
-  },
-  {
-    "code": "Swinub",
-    "name": "Swinub",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swinub.png",
-    "obs_code": "pokemon_1517351921"
-  },
-  {
-    "code": "Piloswine",
-    "name": "Piloswine",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/piloswine.png",
-    "obs_code": "pokemon_3771589817"
-  },
-  {
-    "code": "Corsola",
-    "name": "Corsola",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/corsola.png",
-    "obs_code": "pokemon_386227274"
-  },
-  {
-    "code": "Remoraid",
-    "name": "Remoraid",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/remoraid.png",
-    "obs_code": "pokemon_2049306862"
-  },
-  {
-    "code": "Octillery",
-    "name": "Octillery",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/octillery.png",
-    "obs_code": "pokemon_3493892698"
-  },
-  {
-    "code": "Delibird",
-    "name": "Delibird",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/delibird.png",
-    "obs_code": "pokemon_212992572"
-  },
-  {
-    "code": "Mantine",
-    "name": "Mantine",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mantine.png",
-    "obs_code": "pokemon_4038055089"
-  },
-  {
-    "code": "Skarmory",
-    "name": "Skarmory",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skarmory.png",
-    "obs_code": "pokemon_1839177191"
-  },
-  {
-    "code": "Houndour",
-    "name": "Houndour",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/houndour.png",
-    "obs_code": "pokemon_4019940181"
-  },
-  {
-    "code": "Houndoom",
-    "name": "Houndoom",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/houndoom.png",
-    "obs_code": "pokemon_3093640368"
-  },
-  {
-    "code": "Kingdra",
-    "name": "Kingdra",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kingdra.png",
-    "obs_code": "pokemon_776135513"
-  },
-  {
-    "code": "Phanpy",
-    "name": "Phanpy",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/phanpy.png",
-    "obs_code": "pokemon_2228474235"
-  },
-  {
-    "code": "Donphan",
-    "name": "Donphan",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/donphan.png",
-    "obs_code": "pokemon_3213426967"
-  },
-  {
-    "code": "Porygon2",
-    "name": "Porygon2",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/porygon2.png",
-    "obs_code": "pokemon_2524580645"
-  },
-  {
-    "code": "Stantler",
-    "name": "Stantler",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stantler.png",
-    "obs_code": "pokemon_3152632706"
-  },
-  {
-    "code": "Smeargle",
-    "name": "Smeargle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/smeargle.png",
-    "obs_code": "pokemon_2926893187"
-  },
-  {
-    "code": "Tyrogue",
-    "name": "Tyrogue",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tyrogue.png",
-    "obs_code": "pokemon_97755874"
-  },
-  {
-    "code": "Hitmontop",
-    "name": "Hitmontop",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hitmontop.png",
-    "obs_code": "pokemon_2586826103"
-  },
-  {
-    "code": "Smoochum",
-    "name": "Smoochum",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/smoochum.png",
-    "obs_code": "pokemon_440467624"
-  },
-  {
-    "code": "Elekid",
-    "name": "Elekid",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/elekid.png",
-    "obs_code": "pokemon_1125535919"
-  },
-  {
-    "code": "Magby",
-    "name": "Magby",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magby.png",
-    "obs_code": "pokemon_198190773"
-  },
-  {
-    "code": "Miltank",
-    "name": "Miltank",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/miltank.png",
-    "obs_code": "pokemon_276710205"
-  },
-  {
-    "code": "Blissey",
-    "name": "Blissey",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/blissey.png",
-    "obs_code": "pokemon_945787358"
-  },
-  {
-    "code": "Raikou",
-    "name": "Raikou",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/raikou.png",
-    "obs_code": "pokemon_1797678382"
-  },
-  {
-    "code": "Entei",
-    "name": "Entei",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/entei.png",
-    "obs_code": "pokemon_179130998"
-  },
-  {
-    "code": "Suicune",
-    "name": "Suicune",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/suicune.png",
-    "obs_code": "pokemon_4061426711"
-  },
-  {
-    "code": "Larvitar",
-    "name": "Larvitar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/larvitar.png",
-    "obs_code": "pokemon_2804138018"
-  },
-  {
-    "code": "Pupitar",
-    "name": "Pupitar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pupitar.png",
-    "obs_code": "pokemon_1516631934"
-  },
-  {
-    "code": "Tyranitar",
-    "name": "Tyranitar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tyranitar.png",
-    "obs_code": "pokemon_2314478555"
-  },
-  {
-    "code": "Lugia",
-    "name": "Lugia",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lugia.png",
-    "obs_code": "pokemon_170048531"
-  },
-  {
-    "code": "Ho-oh",
-    "name": "Ho-oh",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ho-oh.png",
-    "obs_code": "pokemon_177791304"
-  },
-  {
-    "code": "Celebi",
-    "name": "Celebi",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/celebi.png",
-    "obs_code": "pokemon_1619088929"
-  },
-  {
-    "code": "Treecko",
-    "name": "Treecko",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/treecko.png",
-    "obs_code": "pokemon_4123740036"
-  },
-  {
-    "code": "Grovyle",
-    "name": "Grovyle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/grovyle.png",
-    "obs_code": "pokemon_4129480537"
-  },
-  {
-    "code": "Sceptile",
-    "name": "Sceptile",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sceptile.png",
-    "obs_code": "pokemon_2541761332"
-  },
-  {
-    "code": "Torchic",
-    "name": "Torchic",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/torchic.png",
-    "obs_code": "pokemon_3796694957"
-  },
-  {
-    "code": "Combusken",
-    "name": "Combusken",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/combusken.png",
-    "obs_code": "pokemon_3140572064"
-  },
-  {
-    "code": "Blaziken",
-    "name": "Blaziken",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/blaziken.png",
-    "obs_code": "pokemon_3854056633"
-  },
-  {
-    "code": "Mudkip",
-    "name": "Mudkip",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mudkip.png",
-    "obs_code": "pokemon_1908241995"
-  },
-  {
-    "code": "Marshtomp",
-    "name": "Marshtomp",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/marshtomp.png",
-    "obs_code": "pokemon_342331942"
-  },
-  {
-    "code": "Swampert",
-    "name": "Swampert",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swampert.png",
-    "obs_code": "pokemon_691597886"
-  },
-  {
-    "code": "Poochyena",
-    "name": "Poochyena",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/poochyena.png",
-    "obs_code": "pokemon_3758673133"
-  },
-  {
-    "code": "Mightyena",
-    "name": "Mightyena",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mightyena.png",
-    "obs_code": "pokemon_3725731401"
-  },
-  {
-    "code": "Zigzagoon",
-    "name": "Zigzagoon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zigzagoon.png",
-    "obs_code": "pokemon_2788681763"
-  },
-  {
-    "code": "Linoone",
-    "name": "Linoone",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/linoone.png",
-    "obs_code": "pokemon_4035754565"
-  },
-  {
-    "code": "Wurmple",
-    "name": "Wurmple",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wurmple.png",
-    "obs_code": "pokemon_4140378177"
-  },
-  {
-    "code": "Silcoon",
-    "name": "Silcoon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/silcoon.png",
-    "obs_code": "pokemon_2846005502"
-  },
-  {
-    "code": "Beautifly",
-    "name": "Beautifly",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/beautifly.png",
-    "obs_code": "pokemon_3157102456"
-  },
-  {
-    "code": "Cascoon",
-    "name": "Cascoon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cascoon.png",
-    "obs_code": "pokemon_2846023737"
-  },
-  {
-    "code": "Dustox",
-    "name": "Dustox",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dustox.png",
-    "obs_code": "pokemon_2195075620"
-  },
-  {
-    "code": "Lotad",
-    "name": "Lotad",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lotad.png",
-    "obs_code": "pokemon_163995415"
-  },
-  {
-    "code": "Lombre",
-    "name": "Lombre",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lombre.png",
-    "obs_code": "pokemon_1168708702"
-  },
-  {
-    "code": "Ludicolo",
-    "name": "Ludicolo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ludicolo.png",
-    "obs_code": "pokemon_2516491678"
-  },
-  {
-    "code": "Seedot",
-    "name": "Seedot",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seedot.png",
-    "obs_code": "pokemon_1754185897"
-  },
-  {
-    "code": "Nuzleaf",
-    "name": "Nuzleaf",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nuzleaf.png",
-    "obs_code": "pokemon_1484305418"
-  },
-  {
-    "code": "Shiftry",
-    "name": "Shiftry",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shiftry.png",
-    "obs_code": "pokemon_473251662"
-  },
-  {
-    "code": "Taillow",
-    "name": "Taillow",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/taillow.png",
-    "obs_code": "pokemon_2340483009"
-  },
-  {
-    "code": "Swellow",
-    "name": "Swellow",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swellow.png",
-    "obs_code": "pokemon_2340486940"
-  },
-  {
-    "code": "Wingull",
-    "name": "Wingull",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wingull.png",
-    "obs_code": "pokemon_4037696903"
-  },
-  {
-    "code": "Pelipper",
-    "name": "Pelipper",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pelipper.png",
-    "obs_code": "pokemon_2100139842"
-  },
-  {
-    "code": "Ralts",
-    "name": "Ralts",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ralts.png",
-    "obs_code": "pokemon_195044669"
-  },
-  {
-    "code": "Kirlia",
-    "name": "Kirlia",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kirlia.png",
-    "obs_code": "pokemon_1316384209"
-  },
-  {
-    "code": "Gardevoir",
-    "name": "Gardevoir",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gardevoir.png",
-    "obs_code": "pokemon_1801395602"
-  },
-  {
-    "code": "Surskit",
-    "name": "Surskit",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/surskit.png",
-    "obs_code": "pokemon_1970965684"
-  },
-  {
-    "code": "Masquerain",
-    "name": "Masquerain",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/masquerain.png",
-    "obs_code": "pokemon_518097679"
-  },
-  {
-    "code": "Shroomish",
-    "name": "Shroomish",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shroomish.png",
-    "obs_code": "pokemon_1807930291"
-  },
-  {
-    "code": "Breloom",
-    "name": "Breloom",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/breloom.png",
-    "obs_code": "pokemon_1134672945"
-  },
-  {
-    "code": "Slakoth",
-    "name": "Slakoth",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slakoth.png",
-    "obs_code": "pokemon_1227788003"
-  },
-  {
-    "code": "Vigoroth",
-    "name": "Vigoroth",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vigoroth.png",
-    "obs_code": "pokemon_1826052467"
-  },
-  {
-    "code": "Slaking",
-    "name": "Slaking",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slaking.png",
-    "obs_code": "pokemon_2888534256"
-  },
-  {
-    "code": "Nincada",
-    "name": "Nincada",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nincada.png",
-    "obs_code": "pokemon_70514699"
-  },
-  {
-    "code": "Ninjask",
-    "name": "Ninjask",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ninjask.png",
-    "obs_code": "pokemon_1631494815"
-  },
-  {
-    "code": "Shedinja",
-    "name": "Shedinja",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shedinja.png",
-    "obs_code": "pokemon_2167913587"
-  },
-  {
-    "code": "Whismur",
-    "name": "Whismur",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/whismur.png",
-    "obs_code": "pokemon_770874570"
-  },
-  {
-    "code": "Loudred",
-    "name": "Loudred",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/loudred.png",
-    "obs_code": "pokemon_2655922628"
-  },
-  {
-    "code": "Exploud",
-    "name": "Exploud",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/exploud.png",
-    "obs_code": "pokemon_3266739194"
-  },
-  {
-    "code": "Makuhita",
-    "name": "Makuhita",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/makuhita.png",
-    "obs_code": "pokemon_1819475395"
-  },
-  {
-    "code": "Hariyama",
-    "name": "Hariyama",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hariyama.png",
-    "obs_code": "pokemon_2936269891"
-  },
-  {
-    "code": "Azurill",
-    "name": "Azurill",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/azurill.png",
-    "obs_code": "pokemon_4033110864"
-  },
-  {
-    "code": "Nosepass",
-    "name": "Nosepass",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nosepass.png",
-    "obs_code": "pokemon_1303154947"
-  },
-  {
-    "code": "Skitty",
-    "name": "Skitty",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skitty.png",
-    "obs_code": "pokemon_2224660365"
-  },
-  {
-    "code": "Delcatty",
-    "name": "Delcatty",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/delcatty.png",
-    "obs_code": "pokemon_302787059"
-  },
-  {
-    "code": "Sableye",
-    "name": "Sableye",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sableye.png",
-    "obs_code": "pokemon_265129472"
-  },
-  {
-    "code": "Mawile",
-    "name": "Mawile",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mawile.png",
-    "obs_code": "pokemon_1165800574"
-  },
-  {
-    "code": "Aron",
-    "name": "Aron",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aron.png",
-    "obs_code": "pokemon_2087865879"
-  },
-  {
-    "code": "Lairon",
-    "name": "Lairon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lairon.png",
-    "obs_code": "pokemon_1648248114"
-  },
-  {
-    "code": "Aggron",
-    "name": "Aggron",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aggron.png",
-    "obs_code": "pokemon_1648237431"
-  },
-  {
-    "code": "Meditite",
-    "name": "Meditite",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meditite.png",
-    "obs_code": "pokemon_577139980"
-  },
-  {
-    "code": "Medicham",
-    "name": "Medicham",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/medicham.png",
-    "obs_code": "pokemon_380989223"
-  },
-  {
-    "code": "Electrike",
-    "name": "Electrike",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/electrike.png",
-    "obs_code": "pokemon_1797615051"
-  },
-  {
-    "code": "Manectric",
-    "name": "Manectric",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/manectric.png",
-    "obs_code": "pokemon_4158535597"
-  },
-  {
-    "code": "Plusle",
-    "name": "Plusle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/plusle.png",
-    "obs_code": "pokemon_1166841302"
-  },
-  {
-    "code": "Minun",
-    "name": "Minun",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/minun.png",
-    "obs_code": "pokemon_181136468"
-  },
-  {
-    "code": "Volbeat",
-    "name": "Volbeat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/volbeat.png",
-    "obs_code": "pokemon_1675011458"
-  },
-  {
-    "code": "Illumise",
-    "name": "Illumise",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/illumise.png",
-    "obs_code": "pokemon_1883741675"
-  },
-  {
-    "code": "Roselia",
-    "name": "Roselia",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/roselia.png",
-    "obs_code": "pokemon_490410538"
-  },
-  {
-    "code": "Gulpin",
-    "name": "Gulpin",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gulpin.png",
-    "obs_code": "pokemon_1650552748"
-  },
-  {
-    "code": "Swalot",
-    "name": "Swalot",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swalot.png",
-    "obs_code": "pokemon_1753893879"
-  },
-  {
-    "code": "Carvanha",
-    "name": "Carvanha",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/carvanha.png",
-    "obs_code": "pokemon_442155333"
-  },
-  {
-    "code": "Sharpedo",
-    "name": "Sharpedo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sharpedo.png",
-    "obs_code": "pokemon_4194768915"
-  },
-  {
-    "code": "Wailmer",
-    "name": "Wailmer",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wailmer.png",
-    "obs_code": "pokemon_1396231372"
-  },
-  {
-    "code": "Wailord",
-    "name": "Wailord",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wailord.png",
-    "obs_code": "pokemon_3006410543"
-  },
-  {
-    "code": "Numel",
-    "name": "Numel",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/numel.png",
-    "obs_code": "pokemon_173599514"
-  },
-  {
-    "code": "Camerupt",
-    "name": "Camerupt",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/camerupt.png",
-    "obs_code": "pokemon_3708307052"
-  },
-  {
-    "code": "Torkoal",
-    "name": "Torkoal",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/torkoal.png",
-    "obs_code": "pokemon_4216646885"
-  },
-  {
-    "code": "Spoink",
-    "name": "Spoink",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spoink.png",
-    "obs_code": "pokemon_1830761669"
-  },
-  {
-    "code": "Grumpig",
-    "name": "Grumpig",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/grumpig.png",
-    "obs_code": "pokemon_2954282134"
-  },
-  {
-    "code": "Spinda",
-    "name": "Spinda",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spinda.png",
-    "obs_code": "pokemon_1304309860"
-  },
-  {
-    "code": "Trapinch",
-    "name": "Trapinch",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/trapinch.png",
-    "obs_code": "pokemon_1821196446"
-  },
-  {
-    "code": "Vibrava",
-    "name": "Vibrava",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vibrava.png",
-    "obs_code": "pokemon_622532732"
-  },
-  {
-    "code": "Flygon",
-    "name": "Flygon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/flygon.png",
-    "obs_code": "pokemon_1647793904"
-  },
-  {
-    "code": "Cacnea",
-    "name": "Cacnea",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cacnea.png",
-    "obs_code": "pokemon_1303197518"
-  },
-  {
-    "code": "Cacturne",
-    "name": "Cacturne",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cacturne.png",
-    "obs_code": "pokemon_1131941980"
-  },
-  {
-    "code": "Swablu",
-    "name": "Swablu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swablu.png",
-    "obs_code": "pokemon_1792485467"
-  },
-  {
-    "code": "Altaria",
-    "name": "Altaria",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/altaria.png",
-    "obs_code": "pokemon_530403911"
-  },
-  {
-    "code": "Zangoose",
-    "name": "Zangoose",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zangoose.png",
-    "obs_code": "pokemon_1799283521"
-  },
-  {
-    "code": "Seviper",
-    "name": "Seviper",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seviper.png",
-    "obs_code": "pokemon_1364832235"
-  },
-  {
-    "code": "Lunatone",
-    "name": "Lunatone",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lunatone.png",
-    "obs_code": "pokemon_37988803"
-  },
-  {
-    "code": "Solrock",
-    "name": "Solrock",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/solrock.png",
-    "obs_code": "pokemon_998798912"
-  },
-  {
-    "code": "Barboach",
-    "name": "Barboach",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/barboach.png",
-    "obs_code": "pokemon_2455110291"
-  },
-  {
-    "code": "Whiscash",
-    "name": "Whiscash",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/whiscash.png",
-    "obs_code": "pokemon_1657356697"
-  },
-  {
-    "code": "Corphish",
-    "name": "Corphish",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/corphish.png",
-    "obs_code": "pokemon_1359748689"
-  },
-  {
-    "code": "Crawdaunt",
-    "name": "Crawdaunt",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/crawdaunt.png",
-    "obs_code": "pokemon_3670117000"
-  },
-  {
-    "code": "Baltoy",
-    "name": "Baltoy",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/baltoy.png",
-    "obs_code": "pokemon_2238871496"
-  },
-  {
-    "code": "Claydol",
-    "name": "Claydol",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/claydol.png",
-    "obs_code": "pokemon_3981275029"
-  },
-  {
-    "code": "Lileep",
-    "name": "Lileep",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lileep.png",
-    "obs_code": "pokemon_1894518428"
-  },
-  {
-    "code": "Cradily",
-    "name": "Cradily",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cradily.png",
-    "obs_code": "pokemon_697542285"
-  },
-  {
-    "code": "Anorith",
-    "name": "Anorith",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/anorith.png",
-    "obs_code": "pokemon_1215126082"
-  },
-  {
-    "code": "Armaldo",
-    "name": "Armaldo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/armaldo.png",
-    "obs_code": "pokemon_248314749"
-  },
-  {
-    "code": "Feebas",
-    "name": "Feebas",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/feebas.png",
-    "obs_code": "pokemon_2163463827"
-  },
-  {
-    "code": "Milotic",
-    "name": "Milotic",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/milotic.png",
-    "obs_code": "pokemon_3820258428"
-  },
-  {
-    "code": "Castform",
-    "name": "Castform",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/castform.png",
-    "obs_code": "pokemon_2845154486"
-  },
-  {
-    "code": "Kecleon",
-    "name": "Kecleon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kecleon.png",
-    "obs_code": "pokemon_2830153600"
-  },
-  {
-    "code": "Shuppet",
-    "name": "Shuppet",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shuppet.png",
-    "obs_code": "pokemon_1800366970"
-  },
-  {
-    "code": "Banette",
-    "name": "Banette",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/banette.png",
-    "obs_code": "pokemon_116397000"
-  },
-  {
-    "code": "Duskull",
-    "name": "Duskull",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/duskull.png",
-    "obs_code": "pokemon_4037812569"
-  },
-  {
-    "code": "Dusclops",
-    "name": "Dusclops",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dusclops.png",
-    "obs_code": "pokemon_220658436"
-  },
-  {
-    "code": "Tropius",
-    "name": "Tropius",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tropius.png",
-    "obs_code": "pokemon_1901170931"
-  },
-  {
-    "code": "Chimecho",
-    "name": "Chimecho",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chimecho.png",
-    "obs_code": "pokemon_1496432363"
-  },
-  {
-    "code": "Absol",
-    "name": "Absol",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/absol.png",
-    "obs_code": "pokemon_173268214"
-  },
-  {
-    "code": "Wynaut",
-    "name": "Wynaut",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wynaut.png",
-    "obs_code": "pokemon_1728344197"
-  },
-  {
-    "code": "Snorunt",
-    "name": "Snorunt",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/snorunt.png",
-    "obs_code": "pokemon_1999405322"
-  },
-  {
-    "code": "Glalie",
-    "name": "Glalie",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/glalie.png",
-    "obs_code": "pokemon_1160107183"
-  },
-  {
-    "code": "Spheal",
-    "name": "Spheal",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spheal.png",
-    "obs_code": "pokemon_1429625318"
-  },
-  {
-    "code": "Sealeo",
-    "name": "Sealeo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sealeo.png",
-    "obs_code": "pokemon_1698367316"
-  },
-  {
-    "code": "Walrein",
-    "name": "Walrein",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/walrein.png",
-    "obs_code": "pokemon_2913245519"
-  },
-  {
-    "code": "Clamperl",
-    "name": "Clamperl",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/clamperl.png",
-    "obs_code": "pokemon_1680216077"
-  },
-  {
-    "code": "Huntail",
-    "name": "Huntail",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/huntail.png",
-    "obs_code": "pokemon_3911126790"
-  },
-  {
-    "code": "Gorebyss",
-    "name": "Gorebyss",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gorebyss.png",
-    "obs_code": "pokemon_2221200065"
-  },
-  {
-    "code": "Relicanth",
-    "name": "Relicanth",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/relicanth.png",
-    "obs_code": "pokemon_4102371303"
-  },
-  {
-    "code": "Luvdisc",
-    "name": "Luvdisc",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/luvdisc.png",
-    "obs_code": "pokemon_4194339287"
-  },
-  {
-    "code": "Bagon",
-    "name": "Bagon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bagon.png",
-    "obs_code": "pokemon_180082880"
-  },
-  {
-    "code": "Shelgon",
-    "name": "Shelgon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shelgon.png",
-    "obs_code": "pokemon_2837118769"
-  },
-  {
-    "code": "Salamence",
-    "name": "Salamence",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/salamence.png",
-    "obs_code": "pokemon_616236058"
-  },
-  {
-    "code": "Beldum",
-    "name": "Beldum",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/beldum.png",
-    "obs_code": "pokemon_1487415762"
-  },
-  {
-    "code": "Metang",
-    "name": "Metang",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/metang.png",
-    "obs_code": "pokemon_1389321201"
-  },
-  {
-    "code": "Metagross",
-    "name": "Metagross",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/metagross.png",
-    "obs_code": "pokemon_4004910498"
-  },
-  {
-    "code": "Regirock",
-    "name": "Regirock",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/regirock.png",
-    "obs_code": "pokemon_2895426953"
-  },
-  {
-    "code": "Regice",
-    "name": "Regice",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/regice.png",
-    "obs_code": "pokemon_1158056570"
-  },
-  {
-    "code": "Registeel",
-    "name": "Registeel",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/registeel.png",
-    "obs_code": "pokemon_2331537719"
-  },
-  {
-    "code": "Latias",
-    "name": "Latias",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/latias.png",
-    "obs_code": "pokemon_2163699175"
-  },
-  {
-    "code": "Latios",
-    "name": "Latios",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/latios.png",
-    "obs_code": "pokemon_2170108905"
-  },
-  {
-    "code": "Kyogre",
-    "name": "Kyogre",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kyogre.png",
-    "obs_code": "pokemon_1168809512"
-  },
-  {
-    "code": "Groudon",
-    "name": "Groudon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/groudon.png",
-    "obs_code": "pokemon_2831527503"
-  },
-  {
-    "code": "Rayquaza",
-    "name": "Rayquaza",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rayquaza.png",
-    "obs_code": "pokemon_1676170961"
-  },
-  {
-    "code": "Jirachi",
-    "name": "Jirachi",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jirachi.png",
-    "obs_code": "pokemon_1662822359"
-  },
-  {
-    "code": "Deoxys (Normal Forme)",
-    "name": "Deoxys (Normal Forme)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/deoxys-normal.png",
-    "obs_code": "pokemon_2883007079"
-  },
-  {
-    "code": "Turtwig",
-    "name": "Turtwig",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/turtwig.png",
-    "obs_code": "pokemon_2952594587"
-  },
-  {
-    "code": "Grotle",
-    "name": "Grotle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/grotle.png",
-    "obs_code": "pokemon_1166541410"
-  },
-  {
-    "code": "Torterra",
-    "name": "Torterra",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/torterra.png",
-    "obs_code": "pokemon_3739517660"
-  },
-  {
-    "code": "Chimchar",
-    "name": "Chimchar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chimchar.png",
-    "obs_code": "pokemon_3882596210"
-  },
-  {
-    "code": "Monferno",
-    "name": "Monferno",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/monferno.png",
-    "obs_code": "pokemon_4177271257"
-  },
-  {
-    "code": "Infernape",
-    "name": "Infernape",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/infernape.png",
-    "obs_code": "pokemon_2618909033"
-  },
-  {
-    "code": "Piplup",
-    "name": "Piplup",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/piplup.png",
-    "obs_code": "pokemon_1875599461"
-  },
-  {
-    "code": "Prinplup",
-    "name": "Prinplup",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/prinplup.png",
-    "obs_code": "pokemon_2418197529"
-  },
-  {
-    "code": "Empoleon",
-    "name": "Empoleon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/empoleon.png",
-    "obs_code": "pokemon_3200348026"
-  },
-  {
-    "code": "Starly",
-    "name": "Starly",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/starly.png",
-    "obs_code": "pokemon_2233074532"
-  },
-  {
-    "code": "Staravia",
-    "name": "Staravia",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/staravia.png",
-    "obs_code": "pokemon_166854702"
-  },
-  {
-    "code": "Staraptor",
-    "name": "Staraptor",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/staraptor.png",
-    "obs_code": "pokemon_1502847977"
-  },
-  {
-    "code": "Bidoof",
-    "name": "Bidoof",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bidoof.png",
-    "obs_code": "pokemon_1353375372"
-  },
-  {
-    "code": "Bibarel",
-    "name": "Bibarel",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bibarel.png",
-    "obs_code": "pokemon_102881910"
-  },
-  {
-    "code": "Kricketot",
-    "name": "Kricketot",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kricketot.png",
-    "obs_code": "pokemon_3753099383"
-  },
-  {
-    "code": "Kricketune",
-    "name": "Kricketune",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kricketune.png",
-    "obs_code": "pokemon_1888494802"
-  },
-  {
-    "code": "Shinx",
-    "name": "Shinx",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shinx.png",
-    "obs_code": "pokemon_196656129"
-  },
-  {
-    "code": "Luxio",
-    "name": "Luxio",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/luxio.png",
-    "obs_code": "pokemon_181223746"
-  },
-  {
-    "code": "Luxray",
-    "name": "Luxray",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/luxray.png",
-    "obs_code": "pokemon_2246197646"
-  },
-  {
-    "code": "Budew",
-    "name": "Budew",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/budew.png",
-    "obs_code": "pokemon_191111876"
-  },
-  {
-    "code": "Roserade",
-    "name": "Roserade",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/roserade.png",
-    "obs_code": "pokemon_1115990172"
-  },
-  {
-    "code": "Cranidos",
-    "name": "Cranidos",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cranidos.png",
-    "obs_code": "pokemon_1749739242"
-  },
-  {
-    "code": "Rampardos",
-    "name": "Rampardos",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rampardos.png",
-    "obs_code": "pokemon_1776847936"
-  },
-  {
-    "code": "Shieldon",
-    "name": "Shieldon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shieldon.png",
-    "obs_code": "pokemon_3237443387"
-  },
-  {
-    "code": "Bastiodon",
-    "name": "Bastiodon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bastiodon.png",
-    "obs_code": "pokemon_3947930978"
-  },
-  {
-    "code": "Burmy",
-    "name": "Burmy",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/burmy.png",
-    "obs_code": "pokemon_197786324"
-  },
-  {
-    "code": "Wormadam (Plant Cloak)",
-    "name": "Wormadam (Plant Cloak)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wormadam-plant.png",
-    "obs_code": "pokemon_371712961"
-  },
-  {
-    "code": "Mothim",
-    "name": "Mothim",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mothim.png",
-    "obs_code": "pokemon_1454667039"
-  },
-  {
-    "code": "Combee",
-    "name": "Combee",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/combee.png",
-    "obs_code": "pokemon_1155722502"
-  },
-  {
-    "code": "Vespiquen",
-    "name": "Vespiquen",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vespiquen.png",
-    "obs_code": "pokemon_3596545267"
-  },
-  {
-    "code": "Pachirisu",
-    "name": "Pachirisu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pachirisu.png",
-    "obs_code": "pokemon_1553818507"
-  },
-  {
-    "code": "Buizel",
-    "name": "Buizel",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/buizel.png",
-    "obs_code": "pokemon_1434494184"
-  },
-  {
-    "code": "Floatzel",
-    "name": "Floatzel",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/floatzel.png",
-    "obs_code": "pokemon_3059610022"
-  },
-  {
-    "code": "Cherubi",
-    "name": "Cherubi",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cherubi.png",
-    "obs_code": "pokemon_1908946631"
-  },
-  {
-    "code": "Cherrim",
-    "name": "Cherrim",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cherrim.png",
-    "obs_code": "pokemon_774620143"
-  },
-  {
-    "code": "Shellos",
-    "name": "Shellos",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shellos.png",
-    "obs_code": "pokemon_2907517159"
-  },
-  {
-    "code": "Gastrodon",
-    "name": "Gastrodon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gastrodon.png",
-    "obs_code": "pokemon_3967200572"
-  },
-  {
-    "code": "Ambipom",
-    "name": "Ambipom",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ambipom.png",
-    "obs_code": "pokemon_1154948208"
-  },
-  {
-    "code": "Drifloon",
-    "name": "Drifloon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drifloon.png",
-    "obs_code": "pokemon_3724766974"
-  },
-  {
-    "code": "Drifblim",
-    "name": "Drifblim",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drifblim.png",
-    "obs_code": "pokemon_3724597686"
-  },
-  {
-    "code": "Buneary",
-    "name": "Buneary",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/buneary.png",
-    "obs_code": "pokemon_457590675"
-  },
-  {
-    "code": "Lopunny",
-    "name": "Lopunny",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lopunny.png",
-    "obs_code": "pokemon_631367386"
-  },
-  {
-    "code": "Mismagius",
-    "name": "Mismagius",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mismagius.png",
-    "obs_code": "pokemon_4067727894"
-  },
-  {
-    "code": "Honchkrow",
-    "name": "Honchkrow",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/honchkrow.png",
-    "obs_code": "pokemon_1914657990"
-  },
-  {
-    "code": "Glameow",
-    "name": "Glameow",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/glameow.png",
-    "obs_code": "pokemon_2341286751"
-  },
-  {
-    "code": "Purugly",
-    "name": "Purugly",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/purugly.png",
-    "obs_code": "pokemon_698956117"
-  },
-  {
-    "code": "Chingling",
-    "name": "Chingling",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chingling.png",
-    "obs_code": "pokemon_1278964674"
-  },
-  {
-    "code": "Stunky",
-    "name": "Stunky",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stunky.png",
-    "obs_code": "pokemon_2244233323"
-  },
-  {
-    "code": "Skuntank",
-    "name": "Skuntank",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skuntank.png",
-    "obs_code": "pokemon_541429558"
-  },
-  {
-    "code": "Bronzor",
-    "name": "Bronzor",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bronzor.png",
-    "obs_code": "pokemon_1436210099"
-  },
-  {
-    "code": "Bronzong",
-    "name": "Bronzong",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bronzong.png",
-    "obs_code": "pokemon_615369096"
-  },
-  {
-    "code": "Bonsly",
-    "name": "Bonsly",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bonsly.png",
-    "obs_code": "pokemon_2233047328"
-  },
-  {
-    "code": "Mime Jr.",
-    "name": "Mime Jr.",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mime-jr.png",
-    "obs_code": "pokemon_1644555676"
-  },
-  {
-    "code": "Happiny",
-    "name": "Happiny",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/happiny.png",
-    "obs_code": "pokemon_623173938"
-  },
-  {
-    "code": "Chatot",
-    "name": "Chatot",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chatot.png",
-    "obs_code": "pokemon_1753606400"
-  },
-  {
-    "code": "Spiritomb",
-    "name": "Spiritomb",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spiritomb.png",
-    "obs_code": "pokemon_395269792"
-  },
-  {
-    "code": "Gible",
-    "name": "Gible",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gible.png",
-    "obs_code": "pokemon_165493280"
-  },
-  {
-    "code": "Gabite",
-    "name": "Gabite",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gabite.png",
-    "obs_code": "pokemon_1175848633"
-  },
-  {
-    "code": "Garchomp",
-    "name": "Garchomp",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/garchomp.png",
-    "obs_code": "pokemon_2906394984"
-  },
-  {
-    "code": "Munchlax",
-    "name": "Munchlax",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/munchlax.png",
-    "obs_code": "pokemon_3174522829"
-  },
-  {
-    "code": "Riolu",
-    "name": "Riolu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/riolu.png",
-    "obs_code": "pokemon_184454504"
-  },
-  {
-    "code": "Lucario",
-    "name": "Lucario",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lucario.png",
-    "obs_code": "pokemon_4063120234"
-  },
-  {
-    "code": "Hippopotas",
-    "name": "Hippopotas",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hippopotas.png",
-    "obs_code": "pokemon_4287581586"
-  },
-  {
-    "code": "Hippowdon",
-    "name": "Hippowdon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hippowdon.png",
-    "obs_code": "pokemon_4267304889"
-  },
-  {
-    "code": "Skorupi",
-    "name": "Skorupi",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skorupi.png",
-    "obs_code": "pokemon_2571838764"
-  },
-  {
-    "code": "Drapion",
-    "name": "Drapion",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drapion.png",
-    "obs_code": "pokemon_2844530282"
-  },
-  {
-    "code": "Croagunk",
-    "name": "Croagunk",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/croagunk.png",
-    "obs_code": "pokemon_1303677165"
-  },
-  {
-    "code": "Toxicroak",
-    "name": "Toxicroak",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/toxicroak.png",
-    "obs_code": "pokemon_2023405499"
-  },
-  {
-    "code": "Carnivine",
-    "name": "Carnivine",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/carnivine.png",
-    "obs_code": "pokemon_3758007526"
-  },
-  {
-    "code": "Finneon",
-    "name": "Finneon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/finneon.png",
-    "obs_code": "pokemon_2830355214"
-  },
-  {
-    "code": "Lumineon",
-    "name": "Lumineon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lumineon.png",
-    "obs_code": "pokemon_3207521394"
-  },
-  {
-    "code": "Mantyke",
-    "name": "Mantyke",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mantyke.png",
-    "obs_code": "pokemon_4168882372"
-  },
-  {
-    "code": "Snover",
-    "name": "Snover",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/snover.png",
-    "obs_code": "pokemon_2123692374"
-  },
-  {
-    "code": "Abomasnow",
-    "name": "Abomasnow",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/abomasnow.png",
-    "obs_code": "pokemon_2462166176"
-  },
-  {
-    "code": "Weavile",
-    "name": "Weavile",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/weavile.png",
-    "obs_code": "pokemon_4111640288"
-  },
-  {
-    "code": "Magnezone",
-    "name": "Magnezone",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magnezone.png",
-    "obs_code": "pokemon_1644142011"
-  },
-  {
-    "code": "Lickilicky",
-    "name": "Lickilicky",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lickilicky.png",
-    "obs_code": "pokemon_291792533"
-  },
-  {
-    "code": "Rhyperior",
-    "name": "Rhyperior",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rhyperior.png",
-    "obs_code": "pokemon_144032117"
-  },
-  {
-    "code": "Tangrowth",
-    "name": "Tangrowth",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tangrowth.png",
-    "obs_code": "pokemon_3122010287"
-  },
-  {
-    "code": "Electivire",
-    "name": "Electivire",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/electivire.png",
-    "obs_code": "pokemon_443030495"
-  },
-  {
-    "code": "Magmortar",
-    "name": "Magmortar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magmortar.png",
-    "obs_code": "pokemon_2465539577"
-  },
-  {
-    "code": "Togekiss",
-    "name": "Togekiss",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/togekiss.png",
-    "obs_code": "pokemon_1584239902"
-  },
-  {
-    "code": "Yanmega",
-    "name": "Yanmega",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/yanmega.png",
-    "obs_code": "pokemon_270983805"
-  },
-  {
-    "code": "Leafeon",
-    "name": "Leafeon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/leafeon.png",
-    "obs_code": "pokemon_2830079567"
-  },
-  {
-    "code": "Glaceon",
-    "name": "Glaceon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/glaceon.png",
-    "obs_code": "pokemon_2829689096"
-  },
-  {
-    "code": "Gliscor",
-    "name": "Gliscor",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gliscor.png",
-    "obs_code": "pokemon_1471510922"
-  },
-  {
-    "code": "Mamoswine",
-    "name": "Mamoswine",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mamoswine.png",
-    "obs_code": "pokemon_3771588589"
-  },
-  {
-    "code": "Porygon-Z",
-    "name": "Porygon-Z",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/porygon-z.png",
-    "obs_code": "pokemon_1763752832"
-  },
-  {
-    "code": "Gallade",
-    "name": "Gallade",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gallade.png",
-    "obs_code": "pokemon_3807818979"
-  },
-  {
-    "code": "Probopass",
-    "name": "Probopass",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/probopass.png",
-    "obs_code": "pokemon_62081652"
-  },
-  {
-    "code": "Dusknoir",
-    "name": "Dusknoir",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dusknoir.png",
-    "obs_code": "pokemon_603559286"
-  },
-  {
-    "code": "Froslass",
-    "name": "Froslass",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/froslass.png",
-    "obs_code": "pokemon_1289583200"
-  },
-  {
-    "code": "Rotom",
-    "name": "Rotom",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rotom.png",
-    "obs_code": "pokemon_174590414"
-  },
-  {
-    "code": "Uxie",
-    "name": "Uxie",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/uxie.png",
-    "obs_code": "pokemon_2087418020"
-  },
-  {
-    "code": "Mesprit",
-    "name": "Mesprit",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mesprit.png",
-    "obs_code": "pokemon_1963882113"
-  },
-  {
-    "code": "Azelf",
-    "name": "Azelf",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/azelf.png",
-    "obs_code": "pokemon_171343761"
-  },
-  {
-    "code": "Dialga",
-    "name": "Dialga",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dialga.png",
-    "obs_code": "pokemon_1309959811"
-  },
-  {
-    "code": "Palkia",
-    "name": "Palkia",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/palkia.png",
-    "obs_code": "pokemon_1316474619"
-  },
-  {
-    "code": "Heatran",
-    "name": "Heatran",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/heatran.png",
-    "obs_code": "pokemon_3233907712"
-  },
-  {
-    "code": "Regigigas",
-    "name": "Regigigas",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/regigigas.png",
-    "obs_code": "pokemon_1642163143"
-  },
-  {
-    "code": "Giratina (Altered Forme)",
-    "name": "Giratina (Altered Forme)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/giratina-altered.png",
-    "obs_code": "pokemon_4030310056"
-  },
-  {
-    "code": "Cresselia",
-    "name": "Cresselia",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cresselia.png",
-    "obs_code": "pokemon_1480424048"
-  },
-  {
-    "code": "Phione",
-    "name": "Phione",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/phione.png",
-    "obs_code": "pokemon_1163489360"
-  },
-  {
-    "code": "Manaphy",
-    "name": "Manaphy",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/manaphy.png",
-    "obs_code": "pokemon_826570695"
-  },
-  {
-    "code": "Darkrai",
-    "name": "Darkrai",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/darkrai.png",
-    "obs_code": "pokemon_1958633699"
-  },
-  {
-    "code": "Shaymin (Land Forme)",
-    "name": "Shaymin (Land Forme)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shaymin-land.png",
-    "obs_code": "pokemon_2249683462"
-  },
-  {
-    "code": "Arceus",
-    "name": "Arceus",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/arceus.png",
-    "obs_code": "pokemon_2139860310"
-  },
-  {
-    "code": "Victini",
-    "name": "Victini",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/victini.png",
-    "obs_code": "pokemon_1435802211"
-  },
-  {
-    "code": "Snivy",
-    "name": "Snivy",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/snivy.png",
-    "obs_code": "pokemon_197466078"
-  },
-  {
-    "code": "Servine",
-    "name": "Servine",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/servine.png",
-    "obs_code": "pokemon_4038096757"
-  },
-  {
-    "code": "Serperior",
-    "name": "Serperior",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/serperior.png",
-    "obs_code": "pokemon_144018130"
-  },
-  {
-    "code": "Tepig",
-    "name": "Tepig",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tepig.png",
-    "obs_code": "pokemon_172303178"
-  },
-  {
-    "code": "Pignite",
-    "name": "Pignite",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pignite.png",
-    "obs_code": "pokemon_147874925"
-  },
-  {
-    "code": "Emboar",
-    "name": "Emboar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/emboar.png",
-    "obs_code": "pokemon_2129252627"
-  },
-  {
-    "code": "Oshawott",
-    "name": "Oshawott",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/oshawott.png",
-    "obs_code": "pokemon_4229204136"
-  },
-  {
-    "code": "Dewott",
-    "name": "Dewott",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dewott.png",
-    "obs_code": "pokemon_1727391900"
-  },
-  {
-    "code": "Samurott",
-    "name": "Samurott",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/samurott.png",
-    "obs_code": "pokemon_4216145458"
-  },
-  {
-    "code": "Patrat",
-    "name": "Patrat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/patrat.png",
-    "obs_code": "pokemon_1741985831"
-  },
-  {
-    "code": "Watchog",
-    "name": "Watchog",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/watchog.png",
-    "obs_code": "pokemon_3156139812"
-  },
-  {
-    "code": "Lillipup",
-    "name": "Lillipup",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lillipup.png",
-    "obs_code": "pokemon_2564208828"
-  },
-  {
-    "code": "Herdier",
-    "name": "Herdier",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/herdier.png",
-    "obs_code": "pokemon_1392037248"
-  },
-  {
-    "code": "Stoutland",
-    "name": "Stoutland",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stoutland.png",
-    "obs_code": "pokemon_1807035499"
-  },
-  {
-    "code": "Purrloin",
-    "name": "Purrloin",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/purrloin.png",
-    "obs_code": "pokemon_2008681284"
-  },
-  {
-    "code": "Liepard",
-    "name": "Liepard",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/liepard.png",
-    "obs_code": "pokemon_2989799330"
-  },
-  {
-    "code": "Pansage",
-    "name": "Pansage",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pansage.png",
-    "obs_code": "pokemon_4003618858"
-  },
-  {
-    "code": "Simisage",
-    "name": "Simisage",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/simisage.png",
-    "obs_code": "pokemon_3270642443"
-  },
-  {
-    "code": "Pansear",
-    "name": "Pansear",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pansear.png",
-    "obs_code": "pokemon_1533486655"
-  },
-  {
-    "code": "Simisear",
-    "name": "Simisear",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/simisear.png",
-    "obs_code": "pokemon_3360028158"
-  },
-  {
-    "code": "Panpour",
-    "name": "Panpour",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/panpour.png",
-    "obs_code": "pokemon_773278594"
-  },
-  {
-    "code": "Simipour",
-    "name": "Simipour",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/simipour.png",
-    "obs_code": "pokemon_4043334307"
-  },
-  {
-    "code": "Munna",
-    "name": "Munna",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/munna.png",
-    "obs_code": "pokemon_169874044"
-  },
-  {
-    "code": "Musharna",
-    "name": "Musharna",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/musharna.png",
-    "obs_code": "pokemon_2382875610"
-  },
-  {
-    "code": "Pidove",
-    "name": "Pidove",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pidove.png",
-    "obs_code": "pokemon_1173546340"
-  },
-  {
-    "code": "Tranquill",
-    "name": "Tranquill",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tranquill.png",
-    "obs_code": "pokemon_2488131873"
-  },
-  {
-    "code": "Unfezant",
-    "name": "Unfezant",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/unfezant.png",
-    "obs_code": "pokemon_2290930908"
-  },
-  {
-    "code": "Blitzle",
-    "name": "Blitzle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/blitzle.png",
-    "obs_code": "pokemon_4137631045"
-  },
-  {
-    "code": "Zebstrika",
-    "name": "Zebstrika",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zebstrika.png",
-    "obs_code": "pokemon_1016014574"
-  },
-  {
-    "code": "Roggenrola",
-    "name": "Roggenrola",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/roggenrola.png",
-    "obs_code": "pokemon_2377174467"
-  },
-  {
-    "code": "Boldore",
-    "name": "Boldore",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/boldore.png",
-    "obs_code": "pokemon_4219953272"
-  },
-  {
-    "code": "Gigalith",
-    "name": "Gigalith",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gigalith.png",
-    "obs_code": "pokemon_1479395572"
-  },
-  {
-    "code": "Woobat",
-    "name": "Woobat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/woobat.png",
-    "obs_code": "pokemon_1742544293"
-  },
-  {
-    "code": "Swoobat",
-    "name": "Swoobat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swoobat.png",
-    "obs_code": "pokemon_1669386806"
-  },
-  {
-    "code": "Drilbur",
-    "name": "Drilbur",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drilbur.png",
-    "obs_code": "pokemon_750826163"
-  },
-  {
-    "code": "Excadrill",
-    "name": "Excadrill",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/excadrill.png",
-    "obs_code": "pokemon_2621127141"
-  },
-  {
-    "code": "Audino",
-    "name": "Audino",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/audino.png",
-    "obs_code": "pokemon_1683700221"
-  },
-  {
-    "code": "Timburr",
-    "name": "Timburr",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/timburr.png",
-    "obs_code": "pokemon_662442210"
-  },
-  {
-    "code": "Gurdurr",
-    "name": "Gurdurr",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gurdurr.png",
-    "obs_code": "pokemon_662343924"
-  },
-  {
-    "code": "Conkeldurr",
-    "name": "Conkeldurr",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/conkeldurr.png",
-    "obs_code": "pokemon_791338484"
-  },
-  {
-    "code": "Tympole",
-    "name": "Tympole",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tympole.png",
-    "obs_code": "pokemon_4114095923"
-  },
-  {
-    "code": "Palpitoad",
-    "name": "Palpitoad",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/palpitoad.png",
-    "obs_code": "pokemon_1657885279"
-  },
-  {
-    "code": "Seismitoad",
-    "name": "Seismitoad",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seismitoad.png",
-    "obs_code": "pokemon_3201503187"
-  },
-  {
-    "code": "Throh",
-    "name": "Throh",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/throh.png",
-    "obs_code": "pokemon_177725484"
-  },
-  {
-    "code": "Sawk",
-    "name": "Sawk",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sawk.png",
-    "obs_code": "pokemon_2088066571"
-  },
-  {
-    "code": "Sewaddle",
-    "name": "Sewaddle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sewaddle.png",
-    "obs_code": "pokemon_2726196844"
-  },
-  {
-    "code": "Swadloon",
-    "name": "Swadloon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swadloon.png",
-    "obs_code": "pokemon_3724969350"
-  },
-  {
-    "code": "Leavanny",
-    "name": "Leavanny",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/leavanny.png",
-    "obs_code": "pokemon_3677609603"
-  },
-  {
-    "code": "Venipede",
-    "name": "Venipede",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/venipede.png",
-    "obs_code": "pokemon_962121605"
-  },
-  {
-    "code": "Whirlipede",
-    "name": "Whirlipede",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/whirlipede.png",
-    "obs_code": "pokemon_4075440624"
-  },
-  {
-    "code": "Scolipede",
-    "name": "Scolipede",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scolipede.png",
-    "obs_code": "pokemon_1685324843"
-  },
-  {
-    "code": "Cottonee",
-    "name": "Cottonee",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cottonee.png",
-    "obs_code": "pokemon_297272200"
-  },
-  {
-    "code": "Whimsicott",
-    "name": "Whimsicott",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/whimsicott.png",
-    "obs_code": "pokemon_1051701160"
-  },
-  {
-    "code": "Petilil",
-    "name": "Petilil",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/petilil.png",
-    "obs_code": "pokemon_3916237156"
-  },
-  {
-    "code": "Lilligant",
-    "name": "Lilligant",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lilligant.png",
-    "obs_code": "pokemon_3329974293"
-  },
-  {
-    "code": "Basculin (Red-Striped Form)",
-    "name": "Basculin (Red-Striped Form)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/basculin-red-striped.png",
-    "obs_code": "pokemon_1121322166"
-  },
-  {
-    "code": "Sandile",
-    "name": "Sandile",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sandile.png",
-    "obs_code": "pokemon_4111151101"
-  },
-  {
-    "code": "Krokorok",
-    "name": "Krokorok",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/krokorok.png",
-    "obs_code": "pokemon_1337675009"
-  },
-  {
-    "code": "Krookodile",
-    "name": "Krookodile",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/krookodile.png",
-    "obs_code": "pokemon_4179012380"
-  },
-  {
-    "code": "Darumaka",
-    "name": "Darumaka",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/darumaka.png",
-    "obs_code": "pokemon_2790810305"
-  },
-  {
-    "code": "Darmanitan (Standard Mode)",
-    "name": "Darmanitan (Standard Mode)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/darmanitan-standard.png",
-    "obs_code": "pokemon_1171909268"
-  },
-  {
-    "code": "Maractus",
-    "name": "Maractus",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/maractus.png",
-    "obs_code": "pokemon_3321005931"
-  },
-  {
-    "code": "Dwebble",
-    "name": "Dwebble",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dwebble.png",
-    "obs_code": "pokemon_4128638970"
-  },
-  {
-    "code": "Crustle",
-    "name": "Crustle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/crustle.png",
-    "obs_code": "pokemon_4135734575"
-  },
-  {
-    "code": "Scraggy",
-    "name": "Scraggy",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scraggy.png",
-    "obs_code": "pokemon_1194323775"
-  },
-  {
-    "code": "Scrafty",
-    "name": "Scrafty",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scrafty.png",
-    "obs_code": "pokemon_387640589"
-  },
-  {
-    "code": "Sigilyph",
-    "name": "Sigilyph",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sigilyph.png",
-    "obs_code": "pokemon_1714368252"
-  },
-  {
-    "code": "Yamask",
-    "name": "Yamask",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/yamask.png",
-    "obs_code": "pokemon_1871543081"
-  },
-  {
-    "code": "Cofagrigus",
-    "name": "Cofagrigus",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cofagrigus.png",
-    "obs_code": "pokemon_3749715"
-  },
-  {
-    "code": "Tirtouga",
-    "name": "Tirtouga",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tirtouga.png",
-    "obs_code": "pokemon_971666786"
-  },
-  {
-    "code": "Carracosta",
-    "name": "Carracosta",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/carracosta.png",
-    "obs_code": "pokemon_962399372"
-  },
-  {
-    "code": "Archen",
-    "name": "Archen",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/archen.png",
-    "obs_code": "pokemon_1663901974"
-  },
-  {
-    "code": "Archeops",
-    "name": "Archeops",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/archeops.png",
-    "obs_code": "pokemon_230709204"
-  },
-  {
-    "code": "Trubbish",
-    "name": "Trubbish",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/trubbish.png",
-    "obs_code": "pokemon_1352953316"
-  },
-  {
-    "code": "Garbodor",
-    "name": "Garbodor",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/garbodor.png",
-    "obs_code": "pokemon_1294927781"
-  },
-  {
-    "code": "Zorua",
-    "name": "Zorua",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zorua.png",
-    "obs_code": "pokemon_170186262"
-  },
-  {
-    "code": "Zoroark",
-    "name": "Zoroark",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zoroark.png",
-    "obs_code": "pokemon_1371568789"
-  },
-  {
-    "code": "Minccino",
-    "name": "Minccino",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/minccino.png",
-    "obs_code": "pokemon_3905570439"
-  },
-  {
-    "code": "Cinccino",
-    "name": "Cinccino",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cinccino.png",
-    "obs_code": "pokemon_3905570441"
-  },
-  {
-    "code": "Gothita",
-    "name": "Gothita",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gothita.png",
-    "obs_code": "pokemon_705886893"
-  },
-  {
-    "code": "Gothorita",
-    "name": "Gothorita",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gothorita.png",
-    "obs_code": "pokemon_3832918064"
-  },
-  {
-    "code": "Gothitelle",
-    "name": "Gothitelle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gothitelle.png",
-    "obs_code": "pokemon_2943579340"
-  },
-  {
-    "code": "Solosis",
-    "name": "Solosis",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/solosis.png",
-    "obs_code": "pokemon_2969919667"
-  },
-  {
-    "code": "Duosion",
-    "name": "Duosion",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/duosion.png",
-    "obs_code": "pokemon_2844483360"
-  },
-  {
-    "code": "Reuniclus",
-    "name": "Reuniclus",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/reuniclus.png",
-    "obs_code": "pokemon_468457001"
-  },
-  {
-    "code": "Ducklett",
-    "name": "Ducklett",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ducklett.png",
-    "obs_code": "pokemon_3675448629"
-  },
-  {
-    "code": "Swanna",
-    "name": "Swanna",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swanna.png",
-    "obs_code": "pokemon_1310863169"
-  },
-  {
-    "code": "Vanillite",
-    "name": "Vanillite",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vanillite.png",
-    "obs_code": "pokemon_2201053901"
-  },
-  {
-    "code": "Vanillish",
-    "name": "Vanillish",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vanillish.png",
-    "obs_code": "pokemon_1779396647"
-  },
-  {
-    "code": "Vanilluxe",
-    "name": "Vanilluxe",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vanilluxe.png",
-    "obs_code": "pokemon_816578397"
-  },
-  {
-    "code": "Deerling",
-    "name": "Deerling",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/deerling.png",
-    "obs_code": "pokemon_820073343"
-  },
-  {
-    "code": "Sawsbuck",
-    "name": "Sawsbuck",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sawsbuck.png",
-    "obs_code": "pokemon_3589459852"
-  },
-  {
-    "code": "Emolga",
-    "name": "Emolga",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/emolga.png",
-    "obs_code": "pokemon_1309949448"
-  },
-  {
-    "code": "Karrablast",
-    "name": "Karrablast",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/karrablast.png",
-    "obs_code": "pokemon_4053452870"
-  },
-  {
-    "code": "Escavalier",
-    "name": "Escavalier",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/escavalier.png",
-    "obs_code": "pokemon_988504788"
-  },
-  {
-    "code": "Foongus",
-    "name": "Foongus",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/foongus.png",
-    "obs_code": "pokemon_1898440140"
-  },
-  {
-    "code": "Amoonguss",
-    "name": "Amoonguss",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/amoonguss.png",
-    "obs_code": "pokemon_2091366933"
-  },
-  {
-    "code": "Frillish",
-    "name": "Frillish",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/frillish.png",
-    "obs_code": "pokemon_1355426218"
-  },
-  {
-    "code": "Jellicent",
-    "name": "Jellicent",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jellicent.png",
-    "obs_code": "pokemon_2615611167"
-  },
-  {
-    "code": "Alomomola",
-    "name": "Alomomola",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/alomomola.png",
-    "obs_code": "pokemon_3767546122"
-  },
-  {
-    "code": "Joltik",
-    "name": "Joltik",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/joltik.png",
-    "obs_code": "pokemon_1841551706"
-  },
-  {
-    "code": "Galvantula",
-    "name": "Galvantula",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/galvantula.png",
-    "obs_code": "pokemon_1174086522"
-  },
-  {
-    "code": "Ferroseed",
-    "name": "Ferroseed",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ferroseed.png",
-    "obs_code": "pokemon_3709469886"
-  },
-  {
-    "code": "Ferrothorn",
-    "name": "Ferrothorn",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ferrothorn.png",
-    "obs_code": "pokemon_393636230"
-  },
-  {
-    "code": "Klink",
-    "name": "Klink",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/klink.png",
-    "obs_code": "pokemon_185627918"
-  },
-  {
-    "code": "Klang",
-    "name": "Klang",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/klang.png",
-    "obs_code": "pokemon_172250378"
-  },
-  {
-    "code": "Klinklang",
-    "name": "Klinklang",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/klinklang.png",
-    "obs_code": "pokemon_2399638602"
-  },
-  {
-    "code": "Tynamo",
-    "name": "Tynamo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tynamo.png",
-    "obs_code": "pokemon_1689071717"
-  },
-  {
-    "code": "Eelektrik",
-    "name": "Eelektrik",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/eelektrik.png",
-    "obs_code": "pokemon_3627363875"
-  },
-  {
-    "code": "Eelektross",
-    "name": "Eelektross",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/eelektross.png",
-    "obs_code": "pokemon_2489361614"
-  },
-  {
-    "code": "Elgyem",
-    "name": "Elgyem",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/elgyem.png",
-    "obs_code": "pokemon_1468911962"
-  },
-  {
-    "code": "Beheeyem",
-    "name": "Beheeyem",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/beheeyem.png",
-    "obs_code": "pokemon_1910077915"
-  },
-  {
-    "code": "Litwick",
-    "name": "Litwick",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/litwick.png",
-    "obs_code": "pokemon_996507170"
-  },
-  {
-    "code": "Lampent",
-    "name": "Lampent",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lampent.png",
-    "obs_code": "pokemon_2017156138"
-  },
-  {
-    "code": "Chandelure",
-    "name": "Chandelure",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chandelure.png",
-    "obs_code": "pokemon_4275681134"
-  },
-  {
-    "code": "Axew",
-    "name": "Axew",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/axew.png",
-    "obs_code": "pokemon_2088199534"
-  },
-  {
-    "code": "Fraxure",
-    "name": "Fraxure",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fraxure.png",
-    "obs_code": "pokemon_4190269642"
-  },
-  {
-    "code": "Haxorus",
-    "name": "Haxorus",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/haxorus.png",
-    "obs_code": "pokemon_1911574639"
-  },
-  {
-    "code": "Cubchoo",
-    "name": "Cubchoo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cubchoo.png",
-    "obs_code": "pokemon_4290738362"
-  },
-  {
-    "code": "Beartic",
-    "name": "Beartic",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/beartic.png",
-    "obs_code": "pokemon_3820060751"
-  },
-  {
-    "code": "Cryogonal",
-    "name": "Cryogonal",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cryogonal.png",
-    "obs_code": "pokemon_1571429353"
-  },
-  {
-    "code": "Shelmet",
-    "name": "Shelmet",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shelmet.png",
-    "obs_code": "pokemon_1831461355"
-  },
-  {
-    "code": "Accelgor",
-    "name": "Accelgor",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/accelgor.png",
-    "obs_code": "pokemon_1482573431"
-  },
-  {
-    "code": "Stunfisk",
-    "name": "Stunfisk",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stunfisk.png",
-    "obs_code": "pokemon_1991656526"
-  },
-  {
-    "code": "Mienfoo",
-    "name": "Mienfoo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mienfoo.png",
-    "obs_code": "pokemon_4274531084"
-  },
-  {
-    "code": "Mienshao",
-    "name": "Mienshao",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mienshao.png",
-    "obs_code": "pokemon_1983949023"
-  },
-  {
-    "code": "Druddigon",
-    "name": "Druddigon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/druddigon.png",
-    "obs_code": "pokemon_1438869129"
-  },
-  {
-    "code": "Golett",
-    "name": "Golett",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golett.png",
-    "obs_code": "pokemon_1726883396"
-  },
-  {
-    "code": "Golurk",
-    "name": "Golurk",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golurk.png",
-    "obs_code": "pokemon_1862953389"
-  },
-  {
-    "code": "Pawniard",
-    "name": "Pawniard",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pawniard.png",
-    "obs_code": "pokemon_4210433363"
-  },
-  {
-    "code": "Bisharp",
-    "name": "Bisharp",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bisharp.png",
-    "obs_code": "pokemon_1797899446"
-  },
-  {
-    "code": "Bouffalant",
-    "name": "Bouffalant",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bouffalant.png",
-    "obs_code": "pokemon_4085269099"
-  },
-  {
-    "code": "Rufflet",
-    "name": "Rufflet",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rufflet.png",
-    "obs_code": "pokemon_1823597855"
-  },
-  {
-    "code": "Braviary",
-    "name": "Braviary",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/braviary.png",
-    "obs_code": "pokemon_2211408001"
-  },
-  {
-    "code": "Vullaby",
-    "name": "Vullaby",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vullaby.png",
-    "obs_code": "pokemon_1083450044"
-  },
-  {
-    "code": "Mandibuzz",
-    "name": "Mandibuzz",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mandibuzz.png",
-    "obs_code": "pokemon_945188477"
-  },
-  {
-    "code": "Heatmor",
-    "name": "Heatmor",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/heatmor.png",
-    "obs_code": "pokemon_1459835533"
-  },
-  {
-    "code": "Durant",
-    "name": "Durant",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/durant.png",
-    "obs_code": "pokemon_1753229085"
-  },
-  {
-    "code": "Deino",
-    "name": "Deino",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/deino.png",
-    "obs_code": "pokemon_181171756"
-  },
-  {
-    "code": "Zweilous",
-    "name": "Zweilous",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zweilous.png",
-    "obs_code": "pokemon_2806481089"
-  },
-  {
-    "code": "Hydreigon",
-    "name": "Hydreigon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hydreigon.png",
-    "obs_code": "pokemon_1438235176"
-  },
-  {
-    "code": "Larvesta",
-    "name": "Larvesta",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/larvesta.png",
-    "obs_code": "pokemon_1126365295"
-  },
-  {
-    "code": "Volcarona",
-    "name": "Volcarona",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/volcarona.png",
-    "obs_code": "pokemon_650991424"
-  },
-  {
-    "code": "Cobalion",
-    "name": "Cobalion",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cobalion.png",
-    "obs_code": "pokemon_3641998318"
-  },
-  {
-    "code": "Terrakion",
-    "name": "Terrakion",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/terrakion.png",
-    "obs_code": "pokemon_44742262"
-  },
-  {
-    "code": "Virizion",
-    "name": "Virizion",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/virizion.png",
-    "obs_code": "pokemon_3672949299"
-  },
-  {
-    "code": "Tornadus (Incarnate Forme)",
-    "name": "Tornadus (Incarnate Forme)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tornadus-incarnate.png",
-    "obs_code": "pokemon_1653274245"
-  },
-  {
-    "code": "Thundurus (Incarnate Forme)",
-    "name": "Thundurus (Incarnate Forme)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/thundurus-incarnate.png",
-    "obs_code": "pokemon_419211971"
-  },
-  {
-    "code": "Reshiram",
-    "name": "Reshiram",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/reshiram.png",
-    "obs_code": "pokemon_1543204894"
-  },
-  {
-    "code": "Zekrom",
-    "name": "Zekrom",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zekrom.png",
-    "obs_code": "pokemon_1466728001"
-  },
-  {
-    "code": "Landorus (Incarnate Forme)",
-    "name": "Landorus (Incarnate Forme)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/landorus-incarnate.png",
-    "obs_code": "pokemon_2520970589"
-  },
-  {
-    "code": "Kyurem",
-    "name": "Kyurem",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kyurem.png",
-    "obs_code": "pokemon_1469355096"
-  },
-  {
-    "code": "Keldeo (Ordinary Forme)",
-    "name": "Keldeo (Ordinary Forme)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/keldeo-ordinary.png",
-    "obs_code": "pokemon_3944089648"
-  },
-  {
-    "code": "Meloetta (Aria Forme)",
-    "name": "Meloetta (Aria Forme)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meloetta-aria.png",
-    "obs_code": "pokemon_3254295932"
-  },
-  {
-    "code": "Genesect",
-    "name": "Genesect",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/genesect.png",
-    "obs_code": "pokemon_1281878253"
-  },
-  {
-    "code": "Chespin",
-    "name": "Chespin",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chespin.png",
-    "obs_code": "pokemon_2927410191"
-  },
-  {
-    "code": "Quilladin",
-    "name": "Quilladin",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/quilladin.png",
-    "obs_code": "pokemon_3621054890"
-  },
-  {
-    "code": "Chesnaught",
-    "name": "Chesnaught",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chesnaught.png",
-    "obs_code": "pokemon_3582880185"
-  },
-  {
-    "code": "Fennekin",
-    "name": "Fennekin",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fennekin.png",
-    "obs_code": "pokemon_1862054159"
-  },
-  {
-    "code": "Braixen",
-    "name": "Braixen",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/braixen.png",
-    "obs_code": "pokemon_3388616078"
-  },
-  {
-    "code": "Delphox",
-    "name": "Delphox",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/delphox.png",
-    "obs_code": "pokemon_3740569479"
-  },
-  {
-    "code": "Froakie",
-    "name": "Froakie",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/froakie.png",
-    "obs_code": "pokemon_3917883480"
-  },
-  {
-    "code": "Frogadier",
-    "name": "Frogadier",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/frogadier.png",
-    "obs_code": "pokemon_4117939394"
-  },
-  {
-    "code": "Greninja",
-    "name": "Greninja",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/greninja.png",
-    "obs_code": "pokemon_2167559287"
-  },
-  {
-    "code": "Bunnelby",
-    "name": "Bunnelby",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bunnelby.png",
-    "obs_code": "pokemon_988181504"
-  },
-  {
-    "code": "Diggersby",
-    "name": "Diggersby",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/diggersby.png",
-    "obs_code": "pokemon_3312413655"
-  },
-  {
-    "code": "Fletchling",
-    "name": "Fletchling",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fletchling.png",
-    "obs_code": "pokemon_3138896729"
-  },
-  {
-    "code": "Fletchinder",
-    "name": "Fletchinder",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fletchinder.png",
-    "obs_code": "pokemon_1366629665"
-  },
-  {
-    "code": "Talonflame",
-    "name": "Talonflame",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/talonflame.png",
-    "obs_code": "pokemon_1233626718"
-  },
-  {
-    "code": "Scatterbug",
-    "name": "Scatterbug",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scatterbug.png",
-    "obs_code": "pokemon_2317839667"
-  },
-  {
-    "code": "Spewpa",
-    "name": "Spewpa",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spewpa.png",
-    "obs_code": "pokemon_1326859589"
-  },
-  {
-    "code": "Vivillon",
-    "name": "Vivillon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vivillon.png",
-    "obs_code": "pokemon_3532009668"
-  },
-  {
-    "code": "Litleo",
-    "name": "Litleo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/litleo.png",
-    "obs_code": "pokemon_1698387986"
-  },
-  {
-    "code": "Pyroar",
-    "name": "Pyroar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pyroar.png",
-    "obs_code": "pokemon_2129235586"
-  },
-  {
-    "code": "Flabébé",
-    "name": "Flabébé",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/flabebe.png",
-    "obs_code": "pokemon_3582283854"
-  },
-  {
-    "code": "Floette",
-    "name": "Floette",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/floette.png",
-    "obs_code": "pokemon_116389408"
-  },
-  {
-    "code": "Florges",
-    "name": "Florges",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/florges.png",
-    "obs_code": "pokemon_2523896163"
-  },
-  {
-    "code": "Skiddo",
-    "name": "Skiddo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skiddo.png",
-    "obs_code": "pokemon_1699760219"
-  },
-  {
-    "code": "Gogoat",
-    "name": "Gogoat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gogoat.png",
-    "obs_code": "pokemon_1742926800"
-  },
-  {
-    "code": "Pancham",
-    "name": "Pancham",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pancham.png",
-    "obs_code": "pokemon_1052756861"
-  },
-  {
-    "code": "Pangoro",
-    "name": "Pangoro",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pangoro.png",
-    "obs_code": "pokemon_493874895"
-  },
-  {
-    "code": "Furfrou",
-    "name": "Furfrou",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/furfrou.png",
-    "obs_code": "pokemon_3486961610"
-  },
-  {
-    "code": "Espurr",
-    "name": "Espurr",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/espurr.png",
-    "obs_code": "pokemon_2102458646"
-  },
-  {
-    "code": "Meowstic (Male)",
-    "name": "Meowstic (Male)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meowstic-male.png",
-    "obs_code": "pokemon_2329455504"
-  },
-  {
-    "code": "Honedge",
-    "name": "Honedge",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/honedge.png",
-    "obs_code": "pokemon_3997331887"
-  },
-  {
-    "code": "Doublade",
-    "name": "Doublade",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/doublade.png",
-    "obs_code": "pokemon_1104351221"
-  },
-  {
-    "code": "Aegislash (Blade Forme)",
-    "name": "Aegislash (Blade Forme)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aegislash-blade.png",
-    "obs_code": "pokemon_1540721929"
-  },
-  {
-    "code": "Spritzee",
-    "name": "Spritzee",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spritzee.png",
-    "obs_code": "pokemon_1065933203"
-  },
-  {
-    "code": "Aromatisse",
-    "name": "Aromatisse",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aromatisse.png",
-    "obs_code": "pokemon_299710509"
-  },
-  {
-    "code": "Swirlix",
-    "name": "Swirlix",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swirlix.png",
-    "obs_code": "pokemon_3965970055"
-  },
-  {
-    "code": "Slurpuff",
-    "name": "Slurpuff",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slurpuff.png",
-    "obs_code": "pokemon_2749106488"
-  },
-  {
-    "code": "Inkay",
-    "name": "Inkay",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/inkay.png",
-    "obs_code": "pokemon_198218353"
-  },
-  {
-    "code": "Malamar",
-    "name": "Malamar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/malamar.png",
-    "obs_code": "pokemon_1543457786"
-  },
-  {
-    "code": "Binacle",
-    "name": "Binacle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/binacle.png",
-    "obs_code": "pokemon_4127753291"
-  },
-  {
-    "code": "Barbaracle",
-    "name": "Barbaracle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/barbaracle.png",
-    "obs_code": "pokemon_575865198"
-  },
-  {
-    "code": "Skrelp",
-    "name": "Skrelp",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skrelp.png",
-    "obs_code": "pokemon_1902654678"
-  },
-  {
-    "code": "Dragalge",
-    "name": "Dragalge",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dragalge.png",
-    "obs_code": "pokemon_3371239322"
-  },
-  {
-    "code": "Clauncher",
-    "name": "Clauncher",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/clauncher.png",
-    "obs_code": "pokemon_606513836"
-  },
-  {
-    "code": "Clawitzer",
-    "name": "Clawitzer",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/clawitzer.png",
-    "obs_code": "pokemon_3466181068"
-  },
-  {
-    "code": "Helioptile",
-    "name": "Helioptile",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/helioptile.png",
-    "obs_code": "pokemon_2026180358"
-  },
-  {
-    "code": "Heliolisk",
-    "name": "Heliolisk",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/heliolisk.png",
-    "obs_code": "pokemon_1672319231"
-  },
-  {
-    "code": "Tyrunt",
-    "name": "Tyrunt",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tyrunt.png",
-    "obs_code": "pokemon_1752544021"
-  },
-  {
-    "code": "Tyrantrum",
-    "name": "Tyrantrum",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tyrantrum.png",
-    "obs_code": "pokemon_3699421611"
-  },
-  {
-    "code": "Amaura",
-    "name": "Amaura",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/amaura.png",
-    "obs_code": "pokemon_1324411630"
-  },
-  {
-    "code": "Aurorus",
-    "name": "Aurorus",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aurorus.png",
-    "obs_code": "pokemon_1911585784"
-  },
-  {
-    "code": "Sylveon",
-    "name": "Sylveon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sylveon.png",
-    "obs_code": "pokemon_2830657041"
-  },
-  {
-    "code": "Hawlucha",
-    "name": "Hawlucha",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hawlucha.png",
-    "obs_code": "pokemon_890740840"
-  },
-  {
-    "code": "Dedenne",
-    "name": "Dedenne",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dedenne.png",
-    "obs_code": "pokemon_4036598016"
-  },
-  {
-    "code": "Carbink",
-    "name": "Carbink",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/carbink.png",
-    "obs_code": "pokemon_285697147"
-  },
-  {
-    "code": "Goomy",
-    "name": "Goomy",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/goomy.png",
-    "obs_code": "pokemon_197808342"
-  },
-  {
-    "code": "Sliggoo",
-    "name": "Sliggoo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sliggoo.png",
-    "obs_code": "pokemon_4275338899"
-  },
-  {
-    "code": "Goodra",
-    "name": "Goodra",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/goodra.png",
-    "obs_code": "pokemon_1325032469"
-  },
-  {
-    "code": "Klefki",
-    "name": "Klefki",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/klefki.png",
-    "obs_code": "pokemon_1617796707"
-  },
-  {
-    "code": "Phantump",
-    "name": "Phantump",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/phantump.png",
-    "obs_code": "pokemon_2671700398"
-  },
-  {
-    "code": "Trevenant",
-    "name": "Trevenant",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/trevenant.png",
-    "obs_code": "pokemon_3064524352"
-  },
-  {
-    "code": "Pumpkaboo (Average Size)",
-    "name": "Pumpkaboo (Average Size)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pumpkaboo-average.png",
-    "obs_code": "pokemon_3668473787"
-  },
-  {
-    "code": "Gourgeist (Average Size)",
-    "name": "Gourgeist (Average Size)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gourgeist-average.png",
-    "obs_code": "pokemon_146342504"
-  },
-  {
-    "code": "Bergmite",
-    "name": "Bergmite",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bergmite.png",
-    "obs_code": "pokemon_588290370"
-  },
-  {
-    "code": "Avalugg",
-    "name": "Avalugg",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/avalugg.png",
-    "obs_code": "pokemon_2859141674"
-  },
-  {
-    "code": "Noibat",
-    "name": "Noibat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/noibat.png",
-    "obs_code": "pokemon_1742546490"
-  },
-  {
-    "code": "Noivern",
-    "name": "Noivern",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/noivern.png",
-    "obs_code": "pokemon_3586800930"
-  },
-  {
-    "code": "Xerneas",
-    "name": "Xerneas",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/xerneas.png",
-    "obs_code": "pokemon_2669564115"
-  },
-  {
-    "code": "Yveltal",
-    "name": "Yveltal",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/yveltal.png",
-    "obs_code": "pokemon_4238695610"
-  },
-  {
-    "code": "Zygarde (50% Forme)",
-    "name": "Zygarde (50% Forme)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zygarde-50.png",
-    "obs_code": "pokemon_2440013563"
-  },
-  {
-    "code": "Diancie",
-    "name": "Diancie",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/diancie.png",
-    "obs_code": "pokemon_3927319176"
-  },
-  {
-    "code": "Hoopa (Hoopa Confined)",
-    "name": "Hoopa (Hoopa Confined)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hoopa-confined.png",
-    "obs_code": "pokemon_3639578611"
-  },
-  {
-    "code": "Volcanion",
-    "name": "Volcanion",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/volcanion.png",
-    "obs_code": "pokemon_156610676"
-  },
-  {
-    "code": "Rowlet",
-    "name": "Rowlet",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rowlet.png",
-    "obs_code": "pokemon_1747198706"
-  },
-  {
-    "code": "Dartrix",
-    "name": "Dartrix",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dartrix.png",
-    "obs_code": "pokemon_3950278469"
-  },
-  {
-    "code": "Decidueye",
-    "name": "Decidueye",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/decidueye.png",
-    "obs_code": "pokemon_620048582"
-  },
-  {
-    "code": "Litten",
-    "name": "Litten",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/litten.png",
-    "obs_code": "pokemon_1664614315"
-  },
-  {
-    "code": "Torracat",
-    "name": "Torracat",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/torracat.png",
-    "obs_code": "pokemon_3499085833"
-  },
-  {
-    "code": "Incineroar",
-    "name": "Incineroar",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/incineroar.png",
-    "obs_code": "pokemon_3577463213"
-  },
-  {
-    "code": "Popplio",
-    "name": "Popplio",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/popplio.png",
-    "obs_code": "pokemon_4065870736"
-  },
-  {
-    "code": "Brionne",
-    "name": "Brionne",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/brionne.png",
-    "obs_code": "pokemon_4036806774"
-  },
-  {
-    "code": "Primarina",
-    "name": "Primarina",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/primarina.png",
-    "obs_code": "pokemon_1487865462"
-  },
-  {
-    "code": "Pikipek",
-    "name": "Pikipek",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pikipek.png",
-    "obs_code": "pokemon_802283616"
-  },
-  {
-    "code": "Trumbeak",
-    "name": "Trumbeak",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/trumbeak.png",
-    "obs_code": "pokemon_537386678"
-  },
-  {
-    "code": "Toucannon",
-    "name": "Toucannon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/toucannon.png",
-    "obs_code": "pokemon_2528902440"
-  },
-  {
-    "code": "Yungoos",
-    "name": "Yungoos",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/yungoos.png",
-    "obs_code": "pokemon_2905882035"
-  },
-  {
-    "code": "Gumshoos",
-    "name": "Gumshoos",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gumshoos.png",
-    "obs_code": "pokemon_1426245586"
-  },
-  {
-    "code": "Grubbin",
-    "name": "Grubbin",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/grubbin.png",
-    "obs_code": "pokemon_2902235106"
-  },
-  {
-    "code": "Charjabug",
-    "name": "Charjabug",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/charjabug.png",
-    "obs_code": "pokemon_2604043654"
-  },
-  {
-    "code": "Vikavolt",
-    "name": "Vikavolt",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vikavolt.png",
-    "obs_code": "pokemon_192725425"
-  },
-  {
-    "code": "Crabrawler",
-    "name": "Crabrawler",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/crabrawler.png",
-    "obs_code": "pokemon_1765735528"
-  },
-  {
-    "code": "Crabominable",
-    "name": "Crabominable",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/crabominable.png",
-    "obs_code": "pokemon_142483096"
-  },
-  {
-    "code": "Oricorio (Baile Style)",
-    "name": "Oricorio (Baile Style)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/oricorio-baile.png",
-    "obs_code": "pokemon_639771015"
-  },
-  {
-    "code": "Cutiefly",
-    "name": "Cutiefly",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cutiefly.png",
-    "obs_code": "pokemon_1643970808"
-  },
-  {
-    "code": "Ribombee",
-    "name": "Ribombee",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ribombee.png",
-    "obs_code": "pokemon_156385084"
-  },
-  {
-    "code": "Rockruff",
-    "name": "Rockruff",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rockruff.png",
-    "obs_code": "pokemon_2755621815"
-  },
-  {
-    "code": "Lycanroc (Midday Form)",
-    "name": "Lycanroc (Midday Form)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lycanroc-midday.png",
-    "obs_code": "pokemon_3297914867"
-  },
-  {
-    "code": "Wishiwashi (Solo Form)",
-    "name": "Wishiwashi (Solo Form)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wishiwashi-solo.png",
-    "obs_code": "pokemon_3960784895"
-  },
-  {
-    "code": "Mareanie",
-    "name": "Mareanie",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mareanie.png",
-    "obs_code": "pokemon_866228605"
-  },
-  {
-    "code": "Toxapex",
-    "name": "Toxapex",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/toxapex.png",
-    "obs_code": "pokemon_4099411882"
-  },
-  {
-    "code": "Mudbray",
-    "name": "Mudbray",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mudbray.png",
-    "obs_code": "pokemon_1109883281"
-  },
-  {
-    "code": "Mudsdale",
-    "name": "Mudsdale",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mudsdale.png",
-    "obs_code": "pokemon_2837263046"
-  },
-  {
-    "code": "Dewpider",
-    "name": "Dewpider",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dewpider.png",
-    "obs_code": "pokemon_2871427769"
-  },
-  {
-    "code": "Araquanid",
-    "name": "Araquanid",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/araquanid.png",
-    "obs_code": "pokemon_552100337"
-  },
-  {
-    "code": "Fomantis",
-    "name": "Fomantis",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fomantis.png",
-    "obs_code": "pokemon_3560106464"
-  },
-  {
-    "code": "Lurantis",
-    "name": "Lurantis",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lurantis.png",
-    "obs_code": "pokemon_3560117999"
-  },
-  {
-    "code": "Morelull",
-    "name": "Morelull",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/morelull.png",
-    "obs_code": "pokemon_103247209"
-  },
-  {
-    "code": "Shiinotic",
-    "name": "Shiinotic",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shiinotic.png",
-    "obs_code": "pokemon_2730853985"
-  },
-  {
-    "code": "Salandit",
-    "name": "Salandit",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/salandit.png",
-    "obs_code": "pokemon_901464589"
-  },
-  {
-    "code": "Salazzle",
-    "name": "Salazzle",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/salazzle.png",
-    "obs_code": "pokemon_3404797299"
-  },
-  {
-    "code": "Stufful",
-    "name": "Stufful",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stufful.png",
-    "obs_code": "pokemon_705280430"
-  },
-  {
-    "code": "Bewear",
-    "name": "Bewear",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bewear.png",
-    "obs_code": "pokemon_2128881283"
-  },
-  {
-    "code": "Bounsweet",
-    "name": "Bounsweet",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bounsweet.png",
-    "obs_code": "pokemon_3823337635"
-  },
-  {
-    "code": "Steenee",
-    "name": "Steenee",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/steenee.png",
-    "obs_code": "pokemon_3783854924"
-  },
-  {
-    "code": "Tsareena",
-    "name": "Tsareena",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tsareena.png",
-    "obs_code": "pokemon_1791977662"
-  },
-  {
-    "code": "Comfey",
-    "name": "Comfey",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/comfey.png",
-    "obs_code": "pokemon_2242152990"
-  },
-  {
-    "code": "Oranguru",
-    "name": "Oranguru",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/oranguru.png",
-    "obs_code": "pokemon_2681027970"
-  },
-  {
-    "code": "Passimian",
-    "name": "Passimian",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/passimian.png",
-    "obs_code": "pokemon_1662836502"
-  },
-  {
-    "code": "Wimpod",
-    "name": "Wimpod",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wimpod.png",
-    "obs_code": "pokemon_1128721325"
-  },
-  {
-    "code": "Golisopod",
-    "name": "Golisopod",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golisopod.png",
-    "obs_code": "pokemon_1239904399"
-  },
-  {
-    "code": "Sandygast",
-    "name": "Sandygast",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sandygast.png",
-    "obs_code": "pokemon_301241381"
-  },
-  {
-    "code": "Palossand",
-    "name": "Palossand",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/palossand.png",
-    "obs_code": "pokemon_2895931644"
-  },
-  {
-    "code": "Pyukumuku",
-    "name": "Pyukumuku",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pyukumuku.png",
-    "obs_code": "pokemon_1267705793"
-  },
-  {
-    "code": "Type: Null",
-    "name": "Type: Null",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/type-null.png",
-    "obs_code": "pokemon_3405451083"
-  },
-  {
-    "code": "Silvally",
-    "name": "Silvally",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/silvally.png",
-    "obs_code": "pokemon_1731047965"
-  },
-  {
-    "code": "Minior (Meteor Form)",
-    "name": "Minior (Meteor Form)",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/minior-meteor.png",
-    "obs_code": "pokemon_276589970"
-  },
-  {
-    "code": "Komala",
-    "name": "Komala",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/komala.png",
-    "obs_code": "pokemon_1313126944"
-  },
-  {
-    "code": "Turtonator",
-    "name": "Turtonator",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/turtonator.png",
-    "obs_code": "pokemon_1468679275"
-  },
-  {
-    "code": "Togedemaru",
-    "name": "Togedemaru",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/togedemaru.png",
-    "obs_code": "pokemon_1860892662"
-  },
-  {
-    "code": "Mimikyu",
-    "name": "Mimikyu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mimikyu.png",
-    "obs_code": "pokemon_2480636002"
-  },
-  {
-    "code": "Bruxish",
-    "name": "Bruxish",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bruxish.png",
-    "obs_code": "pokemon_1342156778"
-  },
-  {
-    "code": "Drampa",
-    "name": "Drampa",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drampa.png",
-    "obs_code": "pokemon_1327505486"
-  },
-  {
-    "code": "Dhelmise",
-    "name": "Dhelmise",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dhelmise.png",
-    "obs_code": "pokemon_1884562770"
-  },
-  {
-    "code": "Jangmo-o",
-    "name": "Jangmo-o",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jangmo-o.png",
-    "obs_code": "pokemon_887519559"
-  },
-  {
-    "code": "Hakamo-o",
-    "name": "Hakamo-o",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hakamo-o.png",
-    "obs_code": "pokemon_887459398"
-  },
-  {
-    "code": "Kommo-o",
-    "name": "Kommo-o",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kommo-o.png",
-    "obs_code": "pokemon_1849004012"
-  },
-  {
-    "code": "Tapu Koko",
-    "name": "Tapu Koko",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tapu-koko.png",
-    "obs_code": "pokemon_211230168"
-  },
-  {
-    "code": "Tapu Lele",
-    "name": "Tapu Lele",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tapu-lele.png",
-    "obs_code": "pokemon_2472646936"
-  },
-  {
-    "code": "Tapu Bulu",
-    "name": "Tapu Bulu",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tapu-bulu.png",
-    "obs_code": "pokemon_418154966"
-  },
-  {
-    "code": "Tapu Fini",
-    "name": "Tapu Fini",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tapu-fini.png",
-    "obs_code": "pokemon_3876093456"
-  },
-  {
-    "code": "Cosmog",
-    "name": "Cosmog",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cosmog.png",
-    "obs_code": "pokemon_1396772351"
-  },
-  {
-    "code": "Cosmoem",
-    "name": "Cosmoem",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cosmoem.png",
-    "obs_code": "pokemon_1203874736"
-  },
-  {
-    "code": "Solgaleo",
-    "name": "Solgaleo",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/solgaleo.png",
-    "obs_code": "pokemon_2685849845"
-  },
-  {
-    "code": "Lunala",
-    "name": "Lunala",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lunala.png",
-    "obs_code": "pokemon_1313124030"
-  },
-  {
-    "code": "Nihilego",
-    "name": "Nihilego",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nihilego.png",
-    "obs_code": "pokemon_862683906"
-  },
-  {
-    "code": "Buzzwole",
-    "name": "Buzzwole",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/buzzwole.png",
-    "obs_code": "pokemon_2619280099"
-  },
-  {
-    "code": "Pheromosa",
-    "name": "Pheromosa",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pheromosa.png",
-    "obs_code": "pokemon_1417644309"
-  },
-  {
-    "code": "Xurkitree",
-    "name": "Xurkitree",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/xurkitree.png",
-    "obs_code": "pokemon_3387334270"
-  },
-  {
-    "code": "Celesteela",
-    "name": "Celesteela",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/celesteela.png",
-    "obs_code": "pokemon_3268203520"
-  },
-  {
-    "code": "Kartana",
-    "name": "Kartana",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kartana.png",
-    "obs_code": "pokemon_310653607"
-  },
-  {
-    "code": "Guzzlord",
-    "name": "Guzzlord",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/guzzlord.png",
-    "obs_code": "pokemon_426700930"
-  },
-  {
-    "code": "Necrozma",
-    "name": "Necrozma",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/necrozma.png",
-    "obs_code": "pokemon_3441775942"
-  },
-  {
-    "code": "Magearna",
-    "name": "Magearna",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magearna.png",
-    "obs_code": "pokemon_2383072055"
-  },
-  {
-    "code": "Marshadow",
-    "name": "Marshadow",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/marshadow.png",
-    "obs_code": "pokemon_2883291485"
-  },
-  {
-    "code": "Poipole",
-    "name": "Poipole",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/poipole.png",
-    "obs_code": "pokemon_4114092261"
-  },
-  {
-    "code": "Naganadel",
-    "name": "Naganadel",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/naganadel.png",
-    "obs_code": "pokemon_1312245902"
-  },
-  {
-    "code": "Stakataka",
-    "name": "Stakataka",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stakataka.png",
-    "obs_code": "pokemon_2852879830"
-  },
-  {
-    "code": "Blacephalon",
-    "name": "Blacephalon",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/blacephalon.png",
-    "obs_code": "pokemon_4144409272"
-  },
-  {
-    "code": "Zeraora",
-    "name": "Zeraora",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zeraora.png",
-    "obs_code": "pokemon_786565397"
-  },
-  {
-    "code": "Meltan",
-    "name": "Meltan",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meltan.png",
-    "obs_code": "pokemon_1660158522"
-  },
-  {
-    "code": "Melmetal",
-    "name": "Melmetal",
-    "url": "https://img.pokemondb.net/sprites/sun-moon/icon/melmetal.png",
-    "obs_code": "pokemon_2445901584"
-  }
+ {
+   "code": "Bulbasaur",
+   "en": "Bulbasaur",
+   "de": "Bisasam",
+   "fr": "Bulbizarre",
+   "ja": "Fushigidane フシギダネ",
+   "ko": "Isanghaessi 이상해씨",
+   "zh": "Miàowāzhǒngzǐ 妙蛙種子",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bulbasaur.png",
+   "obs_code": "pokemon_3655199784"
+ },
+ {
+   "code": "Ivysaur",
+   "en": "Ivysaur",
+   "de": "Bisaknosp",
+   "fr": "Herbizarre",
+   "ja": "Fushigisou フシギソウ",
+   "ko": "Isanghaep'ul 이상해풀",
+   "zh": "Miàowācǎo 妙蛙草",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ivysaur.png",
+   "obs_code": "pokemon_756643862"
+ },
+ {
+   "code": "Venusaur",
+   "en": "Venusaur",
+   "de": "Bisaflor",
+   "fr": "Florizarre",
+   "ja": "Fushigibana フシギバナ",
+   "ko": "Isanghaekkot 이상해꽃",
+   "zh": "Miàowāhuā 妙蛙花",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/venusaur.png",
+   "obs_code": "pokemon_3494250168"
+ },
+ {
+   "code": "Charmander",
+   "en": "Charmander",
+   "de": "Glumanda",
+   "fr": "Salamèche",
+   "ja": "Hitokage ヒトカゲ",
+   "ko": "P'airi 파이리",
+   "zh": "Xiǎohuǒlóng 小火龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/charmander.png",
+   "obs_code": "pokemon_2163171052"
+ },
+ {
+   "code": "Charmeleon",
+   "en": "Charmeleon",
+   "de": "Glutexo",
+   "fr": "Reptincel",
+   "ja": "Lizardo リザード",
+   "ko": "Rijadŭ 리자드",
+   "zh": "Huǒkǒnglóng 火恐龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/charmeleon.png",
+   "obs_code": "pokemon_2322275101"
+ },
+ {
+   "code": "Charizard",
+   "en": "Charizard",
+   "de": "Glurak",
+   "fr": "Dracaufeu",
+   "ja": "Lizardon リザードン",
+   "ko": "Rijamong 리자몽",
+   "zh": "Pēnhuǒlóng 噴火龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/charizard.png",
+   "obs_code": "pokemon_678975897"
+ },
+ {
+   "code": "Squirtle",
+   "en": "Squirtle",
+   "de": "Schiggy",
+   "fr": "Carapuce",
+   "ja": "Zenigame ゼニガメ",
+   "ko": "Kkobugi 꼬부기",
+   "zh": "Jiéníguī 傑尼龜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/squirtle.png",
+   "obs_code": "pokemon_3326135028"
+ },
+ {
+   "code": "Wartortle",
+   "en": "Wartortle",
+   "de": "Schillok",
+   "fr": "Carabaffe",
+   "ja": "Kameil カメール",
+   "ko": "Ŏnibugi 어니부기",
+   "zh": "Kǎmīguī 卡咪龜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wartortle.png",
+   "obs_code": "pokemon_2394918325"
+ },
+ {
+   "code": "Blastoise",
+   "en": "Blastoise",
+   "de": "Turtok",
+   "fr": "Tortank",
+   "ja": "Kamex カメックス",
+   "ko": "Kŏbukwang 거북왕",
+   "zh": "Shuǐjiànguī 水箭龜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/blastoise.png",
+   "obs_code": "pokemon_1803009917"
+ },
+ {
+   "code": "Caterpie",
+   "en": "Caterpie",
+   "de": "Raupy",
+   "fr": "Chenipan",
+   "ja": "Caterpie キャタピー",
+   "ko": "K'aet'ŏp'i 캐터피",
+   "zh": "Lǜmáochóng 綠毛蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/caterpie.png",
+   "obs_code": "pokemon_1405970488"
+ },
+ {
+   "code": "Metapod",
+   "en": "Metapod",
+   "de": "Safcon",
+   "fr": "Chrysacier",
+   "ja": "Trancell トランセル",
+   "ko": "Tandegi 단데기",
+   "zh": "Tiějiáyǒng 鐵甲蛹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/metapod.png",
+   "obs_code": "pokemon_2888465571"
+ },
+ {
+   "code": "Butterfree",
+   "en": "Butterfree",
+   "de": "Smettbo",
+   "fr": "Papilusion",
+   "ja": "Butterfree バタフリー",
+   "ko": "Pŏt'ŏp'ŭl 버터플",
+   "zh": "Bādàhú 巴大蝴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/butterfree.png",
+   "obs_code": "pokemon_991322385"
+ },
+ {
+   "code": "Weedle",
+   "en": "Weedle",
+   "de": "Hornliu",
+   "fr": "Aspicot",
+   "ja": "Beedle ビードル",
+   "ko": "Ppulch'ungi 뿔충이",
+   "zh": "Dújiǎochóng 獨角蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/weedle.png",
+   "obs_code": "pokemon_1165969119"
+ },
+ {
+   "code": "Kakuna",
+   "en": "Kakuna",
+   "de": "Kokuna",
+   "fr": "Coconfort",
+   "ja": "Cocoon コクーン",
+   "ko": "Ttakch'ungi 딱충이",
+   "zh": "Tiěkékūn 鐵殼昆",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kakuna.png",
+   "obs_code": "pokemon_1311611006"
+ },
+ {
+   "code": "Beedrill",
+   "en": "Beedrill",
+   "de": "Bibor",
+   "fr": "Dardagnan",
+   "ja": "Spear スピアー",
+   "ko": "Tokch'imbung 독침붕",
+   "zh": "Dàzhēnfēng 大針蜂",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/beedrill.png",
+   "obs_code": "pokemon_4244249304"
+ },
+ {
+   "code": "Pidgey",
+   "en": "Pidgey",
+   "de": "Taubsi",
+   "fr": "Roucool",
+   "ja": "Poppo ポッポ",
+   "ko": "Kugu 구구",
+   "zh": "Bōbō 波波",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pidgey.png",
+   "obs_code": "pokemon_2241915235"
+ },
+ {
+   "code": "Pidgeotto",
+   "en": "Pidgeotto",
+   "de": "Tauboga",
+   "fr": "Roucoups",
+   "ja": "Pigeon ピジョン",
+   "ko": "P'ijyon 피죤",
+   "zh": "Bǐbǐniǎo 比比鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pidgeotto.png",
+   "obs_code": "pokemon_1277809466"
+ },
+ {
+   "code": "Pidgeot",
+   "en": "Pidgeot",
+   "de": "Tauboss",
+   "fr": "Roucarnage",
+   "ja": "Pigeot ピジョット",
+   "ko": "P'ijyont'u 피죤투",
+   "zh": "Bǐdiāo 比鵰",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pidgeot.png",
+   "obs_code": "pokemon_2061507553"
+ },
+ {
+   "code": "Rattata",
+   "en": "Rattata",
+   "de": "Rattfratz",
+   "fr": "Rattata",
+   "ja": "Koratta コラッタ",
+   "ko": "Kkoret 꼬렛",
+   "zh": "Xiǎolādá 小拉達",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rattata.png",
+   "obs_code": "pokemon_696281826"
+ },
+ {
+   "code": "Raticate",
+   "en": "Raticate",
+   "de": "Rattikarl",
+   "fr": "Rattatac",
+   "ja": "Ratta ラッタ",
+   "ko": "Ret'ŭra 레트라",
+   "zh": "Lādá 拉達",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/raticate.png",
+   "obs_code": "pokemon_287419288"
+ },
+ {
+   "code": "Spearow",
+   "en": "Spearow",
+   "de": "Habitak",
+   "fr": "Piafabec",
+   "ja": "Onisuzume オニスズメ",
+   "ko": "Kkaebich'am 깨비참",
+   "zh": "Lièquè 烈雀",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spearow.png",
+   "obs_code": "pokemon_2332841864"
+ },
+ {
+   "code": "Fearow",
+   "en": "Fearow",
+   "de": "Ibitak",
+   "fr": "Rapasdepic",
+   "ja": "Onidrill オニドリル",
+   "ko": "Kkaebidŭrilcho 깨비드릴조",
+   "zh": "Dàzuǐquè 大嘴雀",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fearow.png",
+   "obs_code": "pokemon_2022950029"
+ },
+ {
+   "code": "Ekans",
+   "en": "Ekans",
+   "de": "Rettan",
+   "fr": "Abo",
+   "ja": "Arbo アーボ",
+   "ko": "Abo 아보",
+   "zh": "Ābóshé 阿柏蛇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ekans.png",
+   "obs_code": "pokemon_195681655"
+ },
+ {
+   "code": "Arbok",
+   "en": "Arbok",
+   "de": "Arbok",
+   "fr": "Arbok",
+   "ja": "Arbok アーボック",
+   "ko": "Abok'ŭ 아보크",
+   "zh": "Ābóguài 阿柏怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/arbok.png",
+   "obs_code": "pokemon_185863856"
+ },
+ {
+   "code": "Pikachu",
+   "en": "Pikachu",
+   "de": "Pikachu",
+   "fr": "Pikachu",
+   "ja": "Pikachu ピカチュウ",
+   "ko": "P'ik'ach'yu 피카츄",
+   "zh": "Píkǎqiū 皮卡丘",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pikachu.png",
+   "obs_code": "pokemon_3159874312"
+ },
+ {
+   "code": "Raichu",
+   "en": "Raichu",
+   "de": "Raichu",
+   "fr": "Raichu",
+   "ja": "Raichu ライチュウ",
+   "ko": "Raich'yu 라이츄",
+   "zh": "Léiqiū 雷丘",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/raichu.png",
+   "obs_code": "pokemon_1787702049"
+ },
+ {
+   "code": "Sandshrew",
+   "en": "Sandshrew",
+   "de": "Sandan",
+   "fr": "Sabelette",
+   "ja": "Sand サンド",
+   "ko": "Moraeduji 모래두지",
+   "zh": "Chuānshānshǔ 穿山鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sandshrew.png",
+   "obs_code": "pokemon_1607652486"
+ },
+ {
+   "code": "Sandslash",
+   "en": "Sandslash",
+   "de": "Sandamer",
+   "fr": "Sablaireau",
+   "ja": "Sandpan サンドパン",
+   "ko": "Koji 고지",
+   "zh": "Chuānshānwáng 穿山王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sandslash.png",
+   "obs_code": "pokemon_2874792856"
+ },
+ {
+   "code": "Nidoran♀",
+   "en": "Nidoran♀",
+   "de": "Nidoran (♀)",
+   "fr": "Nidoran (♀)",
+   "ja": "Nidoran (♀) ニドラン♀",
+   "ko": "Nidŭrŏn (♀) 니드런♀",
+   "zh": "Níduōlán 尼多蘭",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidoran-f.png",
+   "obs_code": "pokemon_2845635167"
+ },
+ {
+   "code": "Nidorina",
+   "en": "Nidorina",
+   "de": "Nidorina",
+   "fr": "Nidorina",
+   "ja": "Nidorina ニドリーナ",
+   "ko": "Nidŭrina 니드리나",
+   "zh": "Níduōnà 尼多娜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidorina.png",
+   "obs_code": "pokemon_1347218269"
+ },
+ {
+   "code": "Nidoqueen",
+   "en": "Nidoqueen",
+   "de": "Nidoqueen",
+   "fr": "Nidoqueen",
+   "ja": "Nidoqueen ニドクイン",
+   "ko": "Nidŭk'win 니드퀸",
+   "zh": "Níduōhòu 尼多后",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidoqueen.png",
+   "obs_code": "pokemon_1511427523"
+ },
+ {
+   "code": "Nidoran♂",
+   "en": "Nidoran♂",
+   "de": "Nidoran (♂)",
+   "fr": "Nidoran (♂)",
+   "ja": "Nidoran (♂) ニドラン (♂)",
+   "ko": "Nidŭrŏn (♂) 니드런 (♂)",
+   "zh": "Níduōláng 尼多朗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidoran-m.png",
+   "obs_code": "pokemon_4223059540"
+ },
+ {
+   "code": "Nidorino",
+   "en": "Nidorino",
+   "de": "Nidorino",
+   "fr": "Nidorino",
+   "ja": "Nidorino ニドリーノ",
+   "ko": "Nidŭrino 니드리노",
+   "zh": "Níduōlìnuò 尼多力諾",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidorino.png",
+   "obs_code": "pokemon_3922806035"
+ },
+ {
+   "code": "Nidoking",
+   "en": "Nidoking",
+   "de": "Nidoking",
+   "fr": "Nidoking",
+   "ja": "Nidoking ニドキング",
+   "ko": "Nidŭk'ing 니드킹",
+   "zh": "Níduōwáng 尼多王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nidoking.png",
+   "obs_code": "pokemon_832003330"
+ },
+ {
+   "code": "Clefairy",
+   "en": "Clefairy",
+   "de": "Piepi",
+   "fr": "Mélofée",
+   "ja": "Pippi ピッピ",
+   "ko": "Ppippi 삐삐",
+   "zh": "Pípí 皮皮",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/clefairy.png",
+   "obs_code": "pokemon_1907242314"
+ },
+ {
+   "code": "Clefable",
+   "en": "Clefable",
+   "de": "Pixi",
+   "fr": "Mélodelfe",
+   "ja": "Pixy ピクシー",
+   "ko": "P'iksi 픽시",
+   "zh": "Píkěsī 皮可西",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/clefable.png",
+   "obs_code": "pokemon_3106758051"
+ },
+ {
+   "code": "Vulpix",
+   "en": "Vulpix",
+   "de": "Vulpix",
+   "fr": "Goupix",
+   "ja": "Rokon ロコン",
+   "ko": "Siksŭt'eil 식스테일",
+   "zh": "Liùwěi 六尾",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vulpix.png",
+   "obs_code": "pokemon_2201895275"
+ },
+ {
+   "code": "Ninetales",
+   "en": "Ninetales",
+   "de": "Vulnona",
+   "fr": "Feunard",
+   "ja": "Kyukon キュウコン",
+   "ko": "Naint'eil 나인테일",
+   "zh": "Jiǔwěi 九尾",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ninetales.png",
+   "obs_code": "pokemon_3975518150"
+ },
+ {
+   "code": "Jigglypuff",
+   "en": "Jigglypuff",
+   "de": "Pummeluff",
+   "fr": "Rondoudou",
+   "ja": "Purin プリン",
+   "ko": "P'urin 푸린",
+   "zh": "Pàngdīng 胖丁",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jigglypuff.png",
+   "obs_code": "pokemon_535745110"
+ },
+ {
+   "code": "Wigglytuff",
+   "en": "Wigglytuff",
+   "de": "Knuddeluff",
+   "fr": "Grodoudou",
+   "ja": "Pukurin プクリン",
+   "ko": "P'ukŭrin 푸크린",
+   "zh": "Pàngkēdīng 胖可丁",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wigglytuff.png",
+   "obs_code": "pokemon_1397441103"
+ },
+ {
+   "code": "Zubat",
+   "en": "Zubat",
+   "de": "Zubat",
+   "fr": "Nosferapti",
+   "ja": "Zubat ズバット",
+   "ko": "Chubaet 주뱃",
+   "zh": "Chāoyīnfú 超音蝠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zubat.png",
+   "obs_code": "pokemon_182954333"
+ },
+ {
+   "code": "Golbat",
+   "en": "Golbat",
+   "de": "Golbat",
+   "fr": "Nosferalto",
+   "ja": "Golbat ゴルバット",
+   "ko": "Kolbaet 골뱃",
+   "zh": "Dàzuǐfú 大嘴蝠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golbat.png",
+   "obs_code": "pokemon_1742551798"
+ },
+ {
+   "code": "Oddish",
+   "en": "Oddish",
+   "de": "Myrapla",
+   "fr": "Mystherbe",
+   "ja": "Nazonokusa ナゾノクサ",
+   "ko": "Ttubŏkch'yo 뚜벅쵸",
+   "zh": "Zǒulùcǎo 走路草",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/oddish.png",
+   "obs_code": "pokemon_1602482040"
+ },
+ {
+   "code": "Gloom",
+   "en": "Gloom",
+   "de": "Duflor",
+   "fr": "Ortide",
+   "ja": "Kusaihana クサイハナ",
+   "ko": "Naemsaekko 냄새꼬",
+   "zh": "Chòuchòuhuā 臭臭花",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gloom.png",
+   "obs_code": "pokemon_174575971"
+ },
+ {
+   "code": "Vileplume",
+   "en": "Vileplume",
+   "de": "Giflor",
+   "fr": "Rafflesia",
+   "ja": "Ruffresia ラフレシア",
+   "ko": "Rapŭllesia 라플레시아",
+   "zh": "Bàwánghuā 霸王花",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vileplume.png",
+   "obs_code": "pokemon_2681015090"
+ },
+ {
+   "code": "Paras",
+   "en": "Paras",
+   "de": "Paras",
+   "fr": "Paras",
+   "ja": "Paras パラス",
+   "ko": "P'arasŭ 파라스",
+   "zh": "Pàilāsī 派拉斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/paras.png",
+   "obs_code": "pokemon_195692756"
+ },
+ {
+   "code": "Parasect",
+   "en": "Parasect",
+   "de": "Parasek",
+   "fr": "Parasect",
+   "ja": "Parasect パラセクト",
+   "ko": "Parasekt'ŭ 파라섹트",
+   "zh": "Pàilāsītè 派拉斯特",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/parasect.png",
+   "obs_code": "pokemon_1282026470"
+ },
+ {
+   "code": "Venonat",
+   "en": "Venonat",
+   "de": "Bluzuk",
+   "fr": "Mimitoss",
+   "ja": "Kongpang コンパン",
+   "ko": "K'onp'ang 콘팡",
+   "zh": "Máoqiú 毛球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/venonat.png",
+   "obs_code": "pokemon_1682780716"
+ },
+ {
+   "code": "Venomoth",
+   "en": "Venomoth",
+   "de": "Omot",
+   "fr": "Aeromite",
+   "ja": "Morphon モルフォン",
+   "ko": "Tonari 도나리",
+   "zh": "Mòrù'é 末入蛾",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/venomoth.png",
+   "obs_code": "pokemon_1855270569"
+ },
+ {
+   "code": "Diglett",
+   "en": "Diglett",
+   "de": "Digda",
+   "fr": "Taupiqueur",
+   "ja": "Digda ディグダ",
+   "ko": "Tigŭda 디그다",
+   "zh": "Dìshǔ 地鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/diglett.png",
+   "obs_code": "pokemon_1152585702"
+ },
+ {
+   "code": "Dugtrio",
+   "en": "Dugtrio",
+   "de": "Digdri",
+   "fr": "Triopiqueur",
+   "ja": "Dugtrio ダグトリオ",
+   "ko": "Takt'ŭrio 닥트리오",
+   "zh": "Sāndìshǔ 三地鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dugtrio.png",
+   "obs_code": "pokemon_4062645395"
+ },
+ {
+   "code": "Meowth",
+   "en": "Meowth",
+   "de": "Mauzi",
+   "fr": "Miaouss",
+   "ja": "Nyarth ニャース",
+   "ko": "Naong 나옹",
+   "zh": "Miāomiāo 喵喵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meowth.png",
+   "obs_code": "pokemon_1598702857"
+ },
+ {
+   "code": "Persian",
+   "en": "Persian",
+   "de": "Snobilikat",
+   "fr": "Persian",
+   "ja": "Persian ペルシアン",
+   "ko": "P'erŭsion 페르시온",
+   "zh": "Māolǎodà 貓老大",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/persian.png",
+   "obs_code": "pokemon_3212116151"
+ },
+ {
+   "code": "Psyduck",
+   "en": "Psyduck",
+   "de": "Enton",
+   "fr": "Psykokwak",
+   "ja": "Koduck コダック",
+   "ko": "Korap'adŏk 고라파덕",
+   "zh": "Kědáyā 可達鴨",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/psyduck.png",
+   "obs_code": "pokemon_1020034118"
+ },
+ {
+   "code": "Golduck",
+   "en": "Golduck",
+   "de": "Entoron",
+   "fr": "Akwakwak",
+   "ja": "Golduck ゴルダック",
+   "ko": "Koldŏk 골덕",
+   "zh": "Gēdáyā 哥達鴨",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golduck.png",
+   "obs_code": "pokemon_1020039576"
+ },
+ {
+   "code": "Mankey",
+   "en": "Mankey",
+   "de": "Menki",
+   "fr": "Ferosinge",
+   "ja": "Mankey マンキー",
+   "ko": "Mangk'i 망키",
+   "zh": "Hóuguài 猴怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mankey.png",
+   "obs_code": "pokemon_2241503728"
+ },
+ {
+   "code": "Primeape",
+   "en": "Primeape",
+   "de": "Rasaff",
+   "fr": "Colossinge",
+   "ja": "Okorizaru オコリザル",
+   "ko": "Sŏngwŏnsung 성원숭",
+   "zh": "Huǒbàohóu 火爆猴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/primeape.png",
+   "obs_code": "pokemon_3718319538"
+ },
+ {
+   "code": "Growlithe",
+   "en": "Growlithe",
+   "de": "Fukano",
+   "fr": "Caninos",
+   "ja": "Gardie ガーディ",
+   "ko": "Kadi 가디",
+   "zh": "Kǎdìgǒu 卡蒂狗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/growlithe.png",
+   "obs_code": "pokemon_1524079572"
+ },
+ {
+   "code": "Arcanine",
+   "en": "Arcanine",
+   "de": "Arkani",
+   "fr": "Arcanin",
+   "ja": "Windie ウインディ",
+   "ko": "Windi 윈디",
+   "zh": "Fēngsùgǒu 風速狗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/arcanine.png",
+   "obs_code": "pokemon_104116984"
+ },
+ {
+   "code": "Poliwag",
+   "en": "Poliwag",
+   "de": "Quapsel",
+   "fr": "Ptitart",
+   "ja": "Nyoromo ニョロモ",
+   "ko": "Palch'aengi 발챙이",
+   "zh": "Wénxiāngkēdǒu 蚊香蝌蚪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/poliwag.png",
+   "obs_code": "pokemon_2640456430"
+ },
+ {
+   "code": "Poliwhirl",
+   "en": "Poliwhirl",
+   "de": "Quaputzi",
+   "fr": "Tetarte",
+   "ja": "Nyorozo ニョロゾ",
+   "ko": "Suryukch'aengi 수륙챙이",
+   "zh": "Wénxiāngwā 蚊香蛙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/poliwhirl.png",
+   "obs_code": "pokemon_2235994839"
+ },
+ {
+   "code": "Poliwrath",
+   "en": "Poliwrath",
+   "de": "Quappo",
+   "fr": "Tartard",
+   "ja": "Nyorobon ニョロボン",
+   "ko": "Kangch'aengi 강챙이",
+   "zh": "Kuàiyǒngwā 快泳蛙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/poliwrath.png",
+   "obs_code": "pokemon_2173645383"
+ },
+ {
+   "code": "Abra",
+   "en": "Abra",
+   "de": "Abra",
+   "fr": "Abra",
+   "ja": "Casey ケーシィ",
+   "ko": "K'aeisi 케이시",
+   "zh": "Kǎixī 凱西",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/abra.png",
+   "obs_code": "pokemon_2087569269"
+ },
+ {
+   "code": "Kadabra",
+   "en": "Kadabra",
+   "de": "Kadabra",
+   "fr": "Kadabra",
+   "ja": "Yungerer ユンゲラー",
+   "ko": "Yun'gella 윤겔라",
+   "zh": "Yǒngjílā 勇吉拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kadabra.png",
+   "obs_code": "pokemon_783164059"
+ },
+ {
+   "code": "Alakazam",
+   "en": "Alakazam",
+   "de": "Simsala",
+   "fr": "Alakazam",
+   "ja": "Foodin フーディン",
+   "ko": "Hudin 후딘",
+   "zh": "Húdì 胡地",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/alakazam.png",
+   "obs_code": "pokemon_1239381269"
+ },
+ {
+   "code": "Machop",
+   "en": "Machop",
+   "de": "Machollo",
+   "fr": "Machoc",
+   "ja": "Wanriky ワンリキー",
+   "ko": "Alt'ongmon 알통몬",
+   "zh": "Wànlì 腕力",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/machop.png",
+   "obs_code": "pokemon_1901094205"
+ },
+ {
+   "code": "Machoke",
+   "en": "Machoke",
+   "de": "Maschock",
+   "fr": "Machopeur",
+   "ja": "Goriky ゴーリキー",
+   "ko": "Kŭnyungmon 근육몬",
+   "zh": "Háolì 豪力",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/machoke.png",
+   "obs_code": "pokemon_4148401283"
+ },
+ {
+   "code": "Machamp",
+   "en": "Machamp",
+   "de": "Machomei",
+   "fr": "Mackogneur",
+   "ja": "Kairiky カイリキー",
+   "ko": "Koeryŏkmon 괴력몬",
+   "zh": "Guàilì 怪力",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/machamp.png",
+   "obs_code": "pokemon_2697488990"
+ },
+ {
+   "code": "Bellsprout",
+   "en": "Bellsprout",
+   "de": "Knofensa",
+   "fr": "Chetiflor",
+   "ja": "Madatsubomi マダツボミ",
+   "ko": "Modap'i 모다피",
+   "zh": "Lǎbāyá 喇叭芽",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bellsprout.png",
+   "obs_code": "pokemon_2183703965"
+ },
+ {
+   "code": "Weepinbell",
+   "en": "Weepinbell",
+   "de": "Ultrigaria",
+   "fr": "Boustiflor",
+   "ja": "Utsudon ウツドン",
+   "ko": "Uch'ŭdong 우츠동",
+   "zh": "Kǒudāihuā 口呆花",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/weepinbell.png",
+   "obs_code": "pokemon_1780103490"
+ },
+ {
+   "code": "Victreebel",
+   "en": "Victreebel",
+   "de": "Sarzenia",
+   "fr": "Empiflor",
+   "ja": "Utsubot ウツボット",
+   "ko": "Uch'ŭbot'ŭ 우츠보트",
+   "zh": "Dàshíhuā 大食花",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/victreebel.png",
+   "obs_code": "pokemon_4172198804"
+ },
+ {
+   "code": "Tentacool",
+   "en": "Tentacool",
+   "de": "Tentacha",
+   "fr": "Tentacool",
+   "ja": "Menokurage メノクラゲ",
+   "ko": "Wangnunhae 왕눈해",
+   "zh": "Mǎnǎoshuǐmǔ 瑪瑙水母",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tentacool.png",
+   "obs_code": "pokemon_4003183136"
+ },
+ {
+   "code": "Tentacruel",
+   "en": "Tentacruel",
+   "de": "Tentoxa",
+   "fr": "Tentacruel",
+   "ja": "Dokukurage ドククラゲ",
+   "ko": "Tokp'ari 독파리",
+   "zh": "Dúcìshuǐmǔ 毒刺水母",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tentacruel.png",
+   "obs_code": "pokemon_1722524770"
+ },
+ {
+   "code": "Geodude",
+   "en": "Geodude",
+   "de": "Kleinstein",
+   "fr": "Racaillou",
+   "ja": "Isitsubute イシツブテ",
+   "ko": "Kkomadol 꼬마돌",
+   "zh": "Xiǎoquánshí 小拳石",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/geodude.png",
+   "obs_code": "pokemon_3822066232"
+ },
+ {
+   "code": "Graveler",
+   "en": "Graveler",
+   "de": "Georok",
+   "fr": "Gravalanch",
+   "ja": "Golone ゴローン",
+   "ko": "Teguri 데구리",
+   "zh": "Lónglóngshí 隆隆石",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/graveler.png",
+   "obs_code": "pokemon_3170206169"
+ },
+ {
+   "code": "Golem",
+   "en": "Golem",
+   "de": "Geowaz",
+   "fr": "Grolem",
+   "ja": "Golonya ゴローニャ",
+   "ko": "Ttakkuri 딱구리",
+   "zh": "Lónglóngyán 隆隆岩",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golem.png",
+   "obs_code": "pokemon_174640521"
+ },
+ {
+   "code": "Ponyta",
+   "en": "Ponyta",
+   "de": "Ponita",
+   "fr": "Ponyta",
+   "ja": "Ponyta ポニータ",
+   "ko": "P'onit'a 포니타",
+   "zh": "Xiǎohuǒmǎ 小火馬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ponyta.png",
+   "obs_code": "pokemon_1322323704"
+ },
+ {
+   "code": "Rapidash",
+   "en": "Rapidash",
+   "de": "Gallopa",
+   "fr": "Galopa",
+   "ja": "Gallop ギャロップ",
+   "ko": "Nalssaengma 날쌩마",
+   "zh": "Lièyànmǎ 烈焰馬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rapidash.png",
+   "obs_code": "pokemon_1658606833"
+ },
+ {
+   "code": "Slowpoke",
+   "en": "Slowpoke",
+   "de": "Flegmon",
+   "fr": "Ramoloss",
+   "ja": "Yadon ヤドン",
+   "ko": "Yadon 야돈",
+   "zh": "Dāidāishòu 呆呆獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slowpoke.png",
+   "obs_code": "pokemon_3762039859"
+ },
+ {
+   "code": "Slowbro",
+   "en": "Slowbro",
+   "de": "Lahmus",
+   "fr": "Flagadoss",
+   "ja": "Yadoran ヤドラン",
+   "ko": "Yadoran 야도란",
+   "zh": "Dāihémǎ 呆河馬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slowbro.png",
+   "obs_code": "pokemon_499346493"
+ },
+ {
+   "code": "Magnemite",
+   "en": "Magnemite",
+   "de": "Magnetilo",
+   "fr": "Magneti",
+   "ja": "Coil コイル",
+   "ko": "K'oil 코일",
+   "zh": "Xiǎocíguài 小磁怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magnemite.png",
+   "obs_code": "pokemon_2236810000"
+ },
+ {
+   "code": "Magneton",
+   "en": "Magneton",
+   "de": "Magneton",
+   "fr": "Magneton",
+   "ja": "Rarecoil レアコイル",
+   "ko": "Reŏk'oil 레어코일",
+   "zh": "Sānhéyīcíguài 三合一磁怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magneton.png",
+   "obs_code": "pokemon_3853274864"
+ },
+ {
+   "code": "Farfetch'd",
+   "en": "Farfetch'd",
+   "de": "Porenta",
+   "fr": "Canarticho",
+   "ja": "Kamonegi カモネギ",
+   "ko": "P'aori 파오리",
+   "zh": "Dàcōngyā 大蔥鴨",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/farfetchd.png",
+   "obs_code": "pokemon_1980596776"
+ },
+ {
+   "code": "Doduo",
+   "en": "Doduo",
+   "de": "Dodu",
+   "fr": "Doduo",
+   "ja": "Dodo ドードー",
+   "ko": "Tudu 두두",
+   "zh": "Dūdū 嘟嘟",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/doduo.png",
+   "obs_code": "pokemon_182199568"
+ },
+ {
+   "code": "Dodrio",
+   "en": "Dodrio",
+   "de": "Dodri",
+   "fr": "Dodrio",
+   "ja": "Dodorio ドードリオ",
+   "ko": "Tut'ŭrio 두트리오",
+   "zh": "Dūdūlì 嘟嘟利",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dodrio.png",
+   "obs_code": "pokemon_1684934430"
+ },
+ {
+   "code": "Seel",
+   "en": "Seel",
+   "de": "Jurob",
+   "fr": "Otaria",
+   "ja": "Pawou パウワウ",
+   "ko": "Chyujyu 쥬쥬",
+   "zh": "Xiǎohǎishī 小海獅",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seel.png",
+   "obs_code": "pokemon_2087669242"
+ },
+ {
+   "code": "Dewgong",
+   "en": "Dewgong",
+   "de": "Jugong",
+   "fr": "Lamantine",
+   "ja": "Jugon ジュゴン",
+   "ko": "Chyuregon 쥬레곤",
+   "zh": "Báihǎishī 白海獅",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dewgong.png",
+   "obs_code": "pokemon_2881290514"
+ },
+ {
+   "code": "Grimer",
+   "en": "Grimer",
+   "de": "Sleima",
+   "fr": "Tadmorv",
+   "ja": "Betbeter ベトベター",
+   "ko": "Chilp'ŏgi 질퍽이",
+   "zh": "Chòuní 臭泥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/grimer.png",
+   "obs_code": "pokemon_2124714595"
+ },
+ {
+   "code": "Muk",
+   "en": "Muk",
+   "de": "Sleimok",
+   "fr": "Grotadmorv",
+   "ja": "Betbeton ベトベトン",
+   "ko": "Chilppŏgi 질뻐기",
+   "zh": "Chòuchòuní 臭臭泥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/muk.png",
+   "obs_code": "pokemon_193425206"
+ },
+ {
+   "code": "Shellder",
+   "en": "Shellder",
+   "de": "Muschas",
+   "fr": "Kokiyas",
+   "ja": "Shellder シェルダー",
+   "ko": "Sellŏ 셀러",
+   "zh": "Dàshébèi 大舌貝",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shellder.png",
+   "obs_code": "pokemon_2868218568"
+ },
+ {
+   "code": "Cloyster",
+   "en": "Cloyster",
+   "de": "Austos",
+   "fr": "Crustabri",
+   "ja": "Parshen パルシェン",
+   "ko": "Parŭsel 파르셀",
+   "zh": "Tiějiǎbèi 鐵甲貝",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cloyster.png",
+   "obs_code": "pokemon_2248079084"
+ },
+ {
+   "code": "Gastly",
+   "en": "Gastly",
+   "de": "Nebulak",
+   "fr": "Fantominus",
+   "ja": "Ghos ゴース",
+   "ko": "Koosŭ 고오스",
+   "zh": "Guǐsī 鬼斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gastly.png",
+   "obs_code": "pokemon_2233030097"
+ },
+ {
+   "code": "Haunter",
+   "en": "Haunter",
+   "de": "Alpollo",
+   "fr": "Spectrum",
+   "ja": "Ghost ゴースト",
+   "ko": "Kousŭt'ŭ 고우스트",
+   "zh": "Guǐsītōng 鬼斯通",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/haunter.png",
+   "obs_code": "pokemon_1369260116"
+ },
+ {
+   "code": "Gengar",
+   "en": "Gengar",
+   "de": "Gengar",
+   "fr": "Ectoplasma",
+   "ja": "Gangar ゲンガー",
+   "ko": "P'aent'ŏm 팬텀",
+   "zh": "Gěngguǐ 耿鬼",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gengar.png",
+   "obs_code": "pokemon_2128978205"
+ },
+ {
+   "code": "Onix",
+   "en": "Onix",
+   "de": "Onix",
+   "fr": "Onix",
+   "ja": "Iwark イワーク",
+   "ko": "Rongsŭt'on 롱스톤",
+   "zh": "Dàyánshé 大岩蛇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/onix.png",
+   "obs_code": "pokemon_2088375125"
+ },
+ {
+   "code": "Drowzee",
+   "en": "Drowzee",
+   "de": "Traumato",
+   "fr": "Soporifik",
+   "ja": "Sleep スリープ",
+   "ko": "Sŭllip'ŭ 슬리프",
+   "zh": "Sùlìpǔ 素利普",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drowzee.png",
+   "obs_code": "pokemon_3806497361"
+ },
+ {
+   "code": "Hypno",
+   "en": "Hypno",
+   "de": "Hypno",
+   "fr": "Hypnomade",
+   "ja": "Sleeper スリーパー",
+   "ko": "Sŭllip'ŏ 슬리퍼",
+   "zh": "Sùlìpāi 素利拍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hypno.png",
+   "obs_code": "pokemon_181181541"
+ },
+ {
+   "code": "Krabby",
+   "en": "Krabby",
+   "de": "Krabby",
+   "fr": "Krabby",
+   "ja": "Crab クラブ",
+   "ko": "K'ŭraep 크랩",
+   "zh": "Dàqiánxiè 大鉗蟹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/krabby.png",
+   "obs_code": "pokemon_2245511716"
+ },
+ {
+   "code": "Kingler",
+   "en": "Kingler",
+   "de": "Kingler",
+   "fr": "Krabboss",
+   "ja": "Kingler キングラー",
+   "ko": "K'ingk'ŭraep 킹크랩",
+   "zh": "Jùqiánxiè 巨鉗蟹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kingler.png",
+   "obs_code": "pokemon_1397374005"
+ },
+ {
+   "code": "Voltorb",
+   "en": "Voltorb",
+   "de": "Voltobal",
+   "fr": "Voltorbe",
+   "ja": "Biriridama ビリリダマ",
+   "ko": "Tchiririgong 찌리리공",
+   "zh": "Léidiànqiú 雷電球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/voltorb.png",
+   "obs_code": "pokemon_2713737019"
+ },
+ {
+   "code": "Electrode",
+   "en": "Electrode",
+   "de": "Lektrobal",
+   "fr": "Electrode",
+   "ja": "Marumine マルマイン",
+   "ko": "Pumbol 붐볼",
+   "zh": "Wánpídàn 頑皮彈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/electrode.png",
+   "obs_code": "pokemon_2179400930"
+ },
+ {
+   "code": "Exeggcute",
+   "en": "Exeggcute",
+   "de": "Owei",
+   "fr": "Noeunoeuf",
+   "ja": "Tamatama タマタマ",
+   "ko": "Arari 아라리",
+   "zh": "Dàndàn 蛋蛋",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/exeggcute.png",
+   "obs_code": "pokemon_824178842"
+ },
+ {
+   "code": "Exeggutor",
+   "en": "Exeggutor",
+   "de": "Kokowei",
+   "fr": "Noadkoko",
+   "ja": "Nassy ナッシー",
+   "ko": "Nasi 나시",
+   "zh": "Yédànshù 椰蛋樹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/exeggutor.png",
+   "obs_code": "pokemon_1314473633"
+ },
+ {
+   "code": "Cubone",
+   "en": "Cubone",
+   "de": "Tragosso",
+   "fr": "Osselait",
+   "ja": "Karakara カラカラ",
+   "ko": "T'angguri 탕구리",
+   "zh": "Kělākělā 可拉可拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cubone.png",
+   "obs_code": "pokemon_1163486965"
+ },
+ {
+   "code": "Marowak",
+   "en": "Marowak",
+   "de": "Knogga",
+   "fr": "Ossatueur",
+   "ja": "Garagara ガラガラ",
+   "ko": "T'ŏngguri 텅구리",
+   "zh": "Gālāgālā 嘎拉嘎拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/marowak.png",
+   "obs_code": "pokemon_948484329"
+ },
+ {
+   "code": "Hitmonlee",
+   "en": "Hitmonlee",
+   "de": "Kicklee",
+   "fr": "Kicklee",
+   "ja": "Sawamular サワムラー",
+   "ko": "Sirasomon 시라소몬",
+   "zh": "Shāwǎláng 沙瓦郎",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hitmonlee.png",
+   "obs_code": "pokemon_2621613808"
+ },
+ {
+   "code": "Hitmonchan",
+   "en": "Hitmonchan",
+   "de": "Nockchan",
+   "fr": "Tygnon",
+   "ja": "Ebiwalar エビワラー",
+   "ko": "Hongsumon 홍수몬",
+   "zh": "Àibǐláng 艾比郎",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hitmonchan.png",
+   "obs_code": "pokemon_2891815448"
+ },
+ {
+   "code": "Lickitung",
+   "en": "Lickitung",
+   "de": "Schlurp",
+   "fr": "Excelangue",
+   "ja": "Beroringa ベロリンガ",
+   "ko": "Naerumi 내루미",
+   "zh": "Dàshétóu 大舌頭",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lickitung.png",
+   "obs_code": "pokemon_701170825"
+ },
+ {
+   "code": "Koffing",
+   "en": "Koffing",
+   "de": "Smogon",
+   "fr": "Smogo",
+   "ja": "Dogars ドガース",
+   "ko": "Ttogasŭ 또가스",
+   "zh": "Wǎsīdàn 瓦斯彈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/koffing.png",
+   "obs_code": "pokemon_2888068641"
+ },
+ {
+   "code": "Weezing",
+   "en": "Weezing",
+   "de": "Smogmog",
+   "fr": "Smogogo",
+   "ja": "Matadogas マタドガス",
+   "ko": "Ttodogasŭ 또도가스",
+   "zh": "Shuāngdànwǎsī 雙彈瓦斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/weezing.png",
+   "obs_code": "pokemon_2889073576"
+ },
+ {
+   "code": "Rhyhorn",
+   "en": "Rhyhorn",
+   "de": "Rihorn",
+   "fr": "Rhinocorne",
+   "ja": "Sihorn サイホーン",
+   "ko": "Ppulk'ano 뿔카노",
+   "zh": "Tiějiǎxīniú 鐵甲犀牛",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rhyhorn.png",
+   "obs_code": "pokemon_3575858717"
+ },
+ {
+   "code": "Rhydon",
+   "en": "Rhydon",
+   "de": "Rizeros",
+   "fr": "Rhinoferos",
+   "ja": "Sidon サイドン",
+   "ko": "K'oppuri 코뿌리",
+   "zh": "Tiějiǎbàolóng 鐵甲暴龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rhydon.png",
+   "obs_code": "pokemon_1647614147"
+ },
+ {
+   "code": "Chansey",
+   "en": "Chansey",
+   "de": "Chaneira",
+   "fr": "Leveinard",
+   "ja": "Lucky ラッキー",
+   "ko": "Rŏkk'i 럭키",
+   "zh": "Jílìdàn 吉利蛋",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chansey.png",
+   "obs_code": "pokemon_945117422"
+ },
+ {
+   "code": "Tangela",
+   "en": "Tangela",
+   "de": "Tangela",
+   "fr": "Saquedeneu",
+   "ja": "Monjara モンジャラ",
+   "ko": "Tŏngguri 덩쿠리",
+   "zh": "Mànténgguài 蔓藤怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tangela.png",
+   "obs_code": "pokemon_388180625"
+ },
+ {
+   "code": "Kangaskhan",
+   "en": "Kangaskhan",
+   "de": "Kangama",
+   "fr": "Kangourex",
+   "ja": "Garura ガルーラ",
+   "ko": "K'aengk'a 캥카",
+   "zh": "Dàilóng 袋龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kangaskhan.png",
+   "obs_code": "pokemon_550269176"
+ },
+ {
+   "code": "Horsea",
+   "en": "Horsea",
+   "de": "Seeper",
+   "fr": "Hypotrempe",
+   "ja": "Tattu タッツー",
+   "ko": "Ssodŭra 쏘드라",
+   "zh": "Mòhǎimǎ 墨海馬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/horsea.png",
+   "obs_code": "pokemon_1303086631"
+ },
+ {
+   "code": "Seadra",
+   "en": "Seadra",
+   "de": "Seemon",
+   "fr": "Hypocean",
+   "ja": "Seadra シードラ",
+   "ko": "Sidŭra 시드라",
+   "zh": "Hǎicìlóng 海刺龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seadra.png",
+   "obs_code": "pokemon_1325026373"
+ },
+ {
+   "code": "Goldeen",
+   "en": "Goldeen",
+   "de": "Goldini",
+   "fr": "Poissirene",
+   "ja": "Tosakinto トサキント",
+   "ko": "K'onch'i 콘치",
+   "zh": "Jiǎojīnyú 角金魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/goldeen.png",
+   "obs_code": "pokemon_3373145803"
+ },
+ {
+   "code": "Seaking",
+   "en": "Seaking",
+   "de": "Golking",
+   "fr": "Poissoroy",
+   "ja": "Azumao アズマオウ",
+   "ko": "Wangk'onch'i 왕콘치",
+   "zh": "Jīnyúwáng 金魚王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seaking.png",
+   "obs_code": "pokemon_2888534297"
+ },
+ {
+   "code": "Staryu",
+   "en": "Staryu",
+   "de": "Sterndu",
+   "fr": "Stari",
+   "ja": "Hitodeman ヒトデマン",
+   "ko": "Pyŏlgasari 별가사리",
+   "zh": "Hǎixīngxīng 海星星",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/staryu.png",
+   "obs_code": "pokemon_1768228349"
+ },
+ {
+   "code": "Starmie",
+   "en": "Starmie",
+   "de": "Starmie",
+   "fr": "Staross",
+   "ja": "Starmie スターミー",
+   "ko": "Ak'usŭt'a 아쿠스타",
+   "zh": "Bǎoshíhǎixīng 寶石海星",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/starmie.png",
+   "obs_code": "pokemon_3925661168"
+ },
+ {
+   "code": "Mr. Mime",
+   "en": "Mr. Mime",
+   "de": "Pantimos",
+   "fr": "M.Mime",
+   "ja": "Barrierd バリヤード",
+   "ko": "Maimmaen 마임맨",
+   "zh": "Xīpánmó'ǒu 吸盤魔偶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mr-mime.png",
+   "obs_code": "pokemon_4076847003"
+ },
+ {
+   "code": "Scyther",
+   "en": "Scyther",
+   "de": "Sichlor",
+   "fr": "Insecateur",
+   "ja": "Strike ストライク",
+   "ko": "Sŭrak'ŭ 스라크",
+   "zh": "Fēitiāntángláng 飛天螳螂",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scyther.png",
+   "obs_code": "pokemon_1392601671"
+ },
+ {
+   "code": "Jynx",
+   "en": "Jynx",
+   "de": "Rossana",
+   "fr": "Lippoutou",
+   "ja": "Rougela ルージュラ",
+   "ko": "Rujura 루주라",
+   "zh": "Míchúnjiě 迷唇姐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jynx.png",
+   "obs_code": "pokemon_2088367136"
+ },
+ {
+   "code": "Electabuzz",
+   "en": "Electabuzz",
+   "de": "Elektek",
+   "fr": "Electek",
+   "ja": "Eleboo エレブー",
+   "ko": "Erebŭ 에레브",
+   "zh": "Diànjíshòu 電擊獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/electabuzz.png",
+   "obs_code": "pokemon_794849320"
+ },
+ {
+   "code": "Magmar",
+   "en": "Magmar",
+   "de": "Magmar",
+   "fr": "Magmar",
+   "ja": "Boober ブーバー",
+   "ko": "Magŭma 마그마",
+   "zh": "Yāzuǐhuǒlóng 鴨嘴火龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magmar.png",
+   "obs_code": "pokemon_2129186320"
+ },
+ {
+   "code": "Pinsir",
+   "en": "Pinsir",
+   "de": "Pinsir",
+   "fr": "Scarabrute",
+   "ja": "Kailios カイロス",
+   "ko": "Ppŭsaijŏ 쁘사이저",
+   "zh": "Dàjiǎ 大甲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pinsir.png",
+   "obs_code": "pokemon_2138008602"
+ },
+ {
+   "code": "Tauros",
+   "en": "Tauros",
+   "de": "Tauros",
+   "fr": "Tauros",
+   "ja": "Kentauros ケンタロス",
+   "ko": "K'ent'arosŭ 켄타로스",
+   "zh": "Kěntàiluó 肯泰羅",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tauros.png",
+   "obs_code": "pokemon_2170026123"
+ },
+ {
+   "code": "Magikarp",
+   "en": "Magikarp",
+   "de": "Karpador",
+   "fr": "Magicarp",
+   "ja": "Koiking コイキング",
+   "ko": "Ingŏk'ing 잉어킹",
+   "zh": "Lǐyúwáng 鯉魚王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magikarp.png",
+   "obs_code": "pokemon_3496369263"
+ },
+ {
+   "code": "Gyarados",
+   "en": "Gyarados",
+   "de": "Garados",
+   "fr": "Leviator",
+   "ja": "Gyarados ギャラドス",
+   "ko": "Kyaradosŭ 갸라도스",
+   "zh": "Bàolǐlóng 暴鯉龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gyarados.png",
+   "obs_code": "pokemon_1758508625"
+ },
+ {
+   "code": "Lapras",
+   "en": "Lapras",
+   "de": "Lapras",
+   "fr": "Lokhlass",
+   "ja": "Laplace ラプラス",
+   "ko": "Rap'ŭrasŭ 라프라스",
+   "zh": "Chénglóng 乘龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lapras.png",
+   "obs_code": "pokemon_2162909528"
+ },
+ {
+   "code": "Ditto",
+   "en": "Ditto",
+   "de": "Ditto",
+   "fr": "Metamorphe",
+   "ja": "Metamon メタモン",
+   "ko": "Met'among 메타몽",
+   "zh": "Bǎibiànguài 百變怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ditto.png",
+   "obs_code": "pokemon_182215975"
+ },
+ {
+   "code": "Eevee",
+   "en": "Eevee",
+   "de": "Evoli",
+   "fr": "Evoli",
+   "ja": "Eievui イーブイ",
+   "ko": "Ibŭ'i 이브이",
+   "zh": "Yībù 伊布",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/eevee.png",
+   "obs_code": "pokemon_165185491"
+ },
+ {
+   "code": "Vaporeon",
+   "en": "Vaporeon",
+   "de": "Aquana",
+   "fr": "Aquali",
+   "ja": "Showers シャワーズ",
+   "ko": "Syamidŭ 샤미드",
+   "zh": "Shuǐjīnglíng 水精靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vaporeon.png",
+   "obs_code": "pokemon_3212751227"
+ },
+ {
+   "code": "Jolteon",
+   "en": "Jolteon",
+   "de": "Blitza",
+   "fr": "Voltali",
+   "ja": "Thunders サンダース",
+   "ko": "Chyup'issŏndŏ 쥬피썬더",
+   "zh": "Léijīnglíng 雷精靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jolteon.png",
+   "obs_code": "pokemon_2830446492"
+ },
+ {
+   "code": "Flareon",
+   "en": "Flareon",
+   "de": "Flamara",
+   "fr": "Pyroli",
+   "ja": "Booster ブースター",
+   "ko": "Busŭt'ŏ 부스터",
+   "zh": "Huǒjīnglíng 火精靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/flareon.png",
+   "obs_code": "pokemon_2830511352"
+ },
+ {
+   "code": "Porygon",
+   "en": "Porygon",
+   "de": "Porygon",
+   "fr": "Porygon",
+   "ja": "Porygon ポリゴン",
+   "ko": "P'olligon 폴리곤",
+   "zh": "3D-Lóng 3D龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/porygon.png",
+   "obs_code": "pokemon_2837572087"
+ },
+ {
+   "code": "Omanyte",
+   "en": "Omanyte",
+   "de": "Amonitas",
+   "fr": "Amonita",
+   "ja": "Omnite オムナイト",
+   "ko": "Amnait'ŭ 암나이트",
+   "zh": "Júshíshòu 菊石獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/omanyte.png",
+   "obs_code": "pokemon_128893920"
+ },
+ {
+   "code": "Omastar",
+   "en": "Omastar",
+   "de": "Amoroso",
+   "fr": "Amonistar",
+   "ja": "Omstar オムスター",
+   "ko": "Amsŭt'a 암스타",
+   "zh": "Duōcìjúshíshòu 多刺菊石獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/omastar.png",
+   "obs_code": "pokemon_1516692594"
+ },
+ {
+   "code": "Kabuto",
+   "en": "Kabuto",
+   "de": "Kabuto",
+   "fr": "Kabuto",
+   "ja": "Kabuto カブト",
+   "ko": "T'ugu 투구",
+   "zh": "Huàshíkuī 化石盔",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kabuto.png",
+   "obs_code": "pokemon_1718129379"
+ },
+ {
+   "code": "Kabutops",
+   "en": "Kabutops",
+   "de": "Kabutops",
+   "fr": "Kabutops",
+   "ja": "Kabutops カブトプス",
+   "ko": "T'ugup'usŭ 투구푸스",
+   "zh": "Liándāokuī 鐮刀盔",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kabutops.png",
+   "obs_code": "pokemon_248170752"
+ },
+ {
+   "code": "Aerodactyl",
+   "en": "Aerodactyl",
+   "de": "Aerodactyl",
+   "fr": "Ptera",
+   "ja": "Ptera プテラ",
+   "ko": "Pŭt'era 프테라",
+   "zh": "Huàshíyìlóng 化石翼龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aerodactyl.png",
+   "obs_code": "pokemon_4053478267"
+ },
+ {
+   "code": "Snorlax",
+   "en": "Snorlax",
+   "de": "Relaxo",
+   "fr": "Ronflex",
+   "ja": "Kabigon カビゴン",
+   "ko": "Chammanbo 잠만보",
+   "zh": "Kǎbǐshòu 卡比獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/snorlax.png",
+   "obs_code": "pokemon_4260093168"
+ },
+ {
+   "code": "Articuno",
+   "en": "Articuno",
+   "de": "Arktos",
+   "fr": "Artikodin",
+   "ja": "Freezer フリーザー",
+   "ko": "Pŭrijyŏ 프리져",
+   "zh": "Jídòngniǎo 急凍鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/articuno.png",
+   "obs_code": "pokemon_4062334460"
+ },
+ {
+   "code": "Zapdos",
+   "en": "Zapdos",
+   "de": "Zapdos",
+   "fr": "Electhor",
+   "ja": "Thunder サンダー",
+   "ko": "Ssŏndŏ 썬더",
+   "zh": "Shǎndiànniǎo 閃電鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zapdos.png",
+   "obs_code": "pokemon_2170780566"
+ },
+ {
+   "code": "Moltres",
+   "en": "Moltres",
+   "de": "Lavados",
+   "fr": "Sulfura",
+   "ja": "Fire ファイヤー",
+   "ko": "P'aiŏ 파이어",
+   "zh": "Huǒyànniǎo 火焰鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/moltres.png",
+   "obs_code": "pokemon_2500142875"
+ },
+ {
+   "code": "Dratini",
+   "en": "Dratini",
+   "de": "Dratini",
+   "fr": "Minidraco",
+   "ja": "Miniryu ミニリュウ",
+   "ko": "Minyong 미뇽",
+   "zh": "Mínǐlóng 迷你龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dratini.png",
+   "obs_code": "pokemon_1435799752"
+ },
+ {
+   "code": "Dragonair",
+   "en": "Dragonair",
+   "de": "Dragonir",
+   "fr": "Draco",
+   "ja": "Hakuryu ハクリュー",
+   "ko": "Sinnyong 신뇽",
+   "zh": "Hākèlóng 哈克龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dragonair.png",
+   "obs_code": "pokemon_1852247310"
+ },
+ {
+   "code": "Dragonite",
+   "en": "Dragonite",
+   "de": "Dragoran",
+   "fr": "Dracolosse",
+   "ja": "Kairyu カイリュー",
+   "ko": "Mangnanyong 망나뇽",
+   "zh": "Kuàilóng 快龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dragonite.png",
+   "obs_code": "pokemon_2131004652"
+ },
+ {
+   "code": "Mewtwo",
+   "en": "Mewtwo",
+   "de": "Mewtu",
+   "fr": "Mewtwo",
+   "ja": "Mewtwo ミュウツー",
+   "ko": "Myuch'ŭ 뮤츠",
+   "zh": "Chāomèng 超夢",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mewtwo.png",
+   "obs_code": "pokemon_1719306326"
+ },
+ {
+   "code": "Mew",
+   "en": "Mew",
+   "de": "Mew",
+   "fr": "Mew",
+   "ja": "Mew ミュウ",
+   "ko": "Myu 뮤",
+   "zh": "Mènghuàn 夢幻",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mew.png",
+   "obs_code": "pokemon_193429306"
+ },
+ {
+   "code": "Chikorita",
+   "en": "Chikorita",
+   "de": "Endivie",
+   "fr": "Germignon",
+   "ja": "Chicorita チコリータ",
+   "ko": "Ch'ik'orit'a 치코리타",
+   "zh": "Júcăoyè 菊草葉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chikorita.png",
+   "obs_code": "pokemon_3833066669"
+ },
+ {
+   "code": "Bayleef",
+   "en": "Bayleef",
+   "de": "Lorblatt",
+   "fr": "Macronium",
+   "ja": "Bayleaf ベイリーフ",
+   "ko": "Peiripŭ 베이리프",
+   "zh": "Yuèguìyè 月桂葉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bayleef.png",
+   "obs_code": "pokemon_1631646677"
+ },
+ {
+   "code": "Meganium",
+   "en": "Meganium",
+   "de": "Meganie",
+   "fr": "Meganium",
+   "ja": "Meganium メガニウム",
+   "ko": "Meganium 메가니움",
+   "zh": "Dàjúhuā 大菊花",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meganium.png",
+   "obs_code": "pokemon_489921044"
+ },
+ {
+   "code": "Cyndaquil",
+   "en": "Cyndaquil",
+   "de": "Feurigel",
+   "fr": "Hericendre",
+   "ja": "Hinoarashi ヒノアラシ",
+   "ko": "Pŭk'ein 브케인",
+   "zh": "Huŏqiúshŭ 火球鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cyndaquil.png",
+   "obs_code": "pokemon_1285047989"
+ },
+ {
+   "code": "Quilava",
+   "en": "Quilava",
+   "de": "Igelavar",
+   "fr": "Feurisson",
+   "ja": "Magmarashi マグマラシ",
+   "ko": "Magŭk'ein 마그케인",
+   "zh": "Huŏyánshŭ 火岩鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/quilava.png",
+   "obs_code": "pokemon_623456498"
+ },
+ {
+   "code": "Typhlosion",
+   "en": "Typhlosion",
+   "de": "Tornupto",
+   "fr": "Typhlosion",
+   "ja": "Bakphoon バクフーン",
+   "ko": "Bŭlleibŏm 블레이범",
+   "zh": "Huŏbàoshòu 火暴獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/typhlosion.png",
+   "obs_code": "pokemon_2004082920"
+ },
+ {
+   "code": "Totodile",
+   "en": "Totodile",
+   "de": "Karnimani",
+   "fr": "Kaiminus",
+   "ja": "Waninoko ワニノコ",
+   "ko": "Riak'o 리아코",
+   "zh": "Xiǎojù'è 小鋸鱷",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/totodile.png",
+   "obs_code": "pokemon_2524045185"
+ },
+ {
+   "code": "Croconaw",
+   "en": "Croconaw",
+   "de": "Tyracroc",
+   "fr": "Crocrodil",
+   "ja": "Alligates アリゲイツ",
+   "ko": "Elligei 엘리게이",
+   "zh": "Lán'è 藍鱷",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/croconaw.png",
+   "obs_code": "pokemon_4152801167"
+ },
+ {
+   "code": "Feraligatr",
+   "en": "Feraligatr",
+   "de": "Impergator",
+   "fr": "Aligatueur",
+   "ja": "Ordile オーダイル",
+   "ko": "Changk'ŭrodail 장크로다일",
+   "zh": "Dàlì'è 大力鱷",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/feraligatr.png",
+   "obs_code": "pokemon_3207191952"
+ },
+ {
+   "code": "Sentret",
+   "en": "Sentret",
+   "de": "Wiesor",
+   "fr": "Fouinette",
+   "ja": "Otachi オタチ",
+   "ko": "Kkorisŏn 꼬리선",
+   "zh": "Wĕilì 尾立",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sentret.png",
+   "obs_code": "pokemon_1807219786"
+ },
+ {
+   "code": "Furret",
+   "en": "Furret",
+   "de": "Wiesenior",
+   "fr": "Fouinar",
+   "ja": "Ootachi オオタチ",
+   "ko": "Takkori 다꼬리",
+   "zh": "Dàwĕilì 大尾立",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/furret.png",
+   "obs_code": "pokemon_1746718119"
+ },
+ {
+   "code": "Hoothoot",
+   "en": "Hoothoot",
+   "de": "Hoothoot",
+   "fr": "Hoothoot",
+   "ja": "Hoho ホーホー",
+   "ko": "Puubu 부우부",
+   "zh": "Gūgū 咕咕",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hoothoot.png",
+   "obs_code": "pokemon_3072252741"
+ },
+ {
+   "code": "Noctowl",
+   "en": "Noctowl",
+   "de": "Noctuh",
+   "fr": "Noarfang",
+   "ja": "Yorunozuku ヨルノズク",
+   "ko": "Yabuŏng 야부엉",
+   "zh": "Māotóuyèyīng 貓頭夜鷹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/noctowl.png",
+   "obs_code": "pokemon_615924295"
+ },
+ {
+   "code": "Ledyba",
+   "en": "Ledyba",
+   "de": "Ledyba",
+   "fr": "Coxy",
+   "ja": "Rediba レディバ",
+   "ko": "Rediba 레디바",
+   "zh": "Bāpiáochóng 芭瓢蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ledyba.png",
+   "obs_code": "pokemon_1307012274"
+ },
+ {
+   "code": "Ledian",
+   "en": "Ledian",
+   "de": "Ledian",
+   "fr": "Coxyclaque",
+   "ja": "Redian レディアン",
+   "ko": "Redian 레디안",
+   "zh": "Ānpiáochóng 安瓢蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ledian.png",
+   "obs_code": "pokemon_1659135694"
+ },
+ {
+   "code": "Spinarak",
+   "en": "Spinarak",
+   "de": "Webarak",
+   "fr": "Mimigal",
+   "ja": "Itomaru イトマル",
+   "ko": "P'eigŏm 페이검",
+   "zh": "Xiànqiú 線球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spinarak.png",
+   "obs_code": "pokemon_1355492472"
+ },
+ {
+   "code": "Ariados",
+   "en": "Ariados",
+   "de": "Ariados",
+   "fr": "Migalos",
+   "ja": "Ariados アリアドス",
+   "ko": "Ariadosŭ 아리아도스",
+   "zh": "Ālìduōsī 阿利多斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ariados.png",
+   "obs_code": "pokemon_2916608838"
+ },
+ {
+   "code": "Crobat",
+   "en": "Crobat",
+   "de": "Iksbat",
+   "fr": "Nostenfer",
+   "ja": "Crobat クロバット",
+   "ko": "K'ŭrobaet 크로뱃",
+   "zh": "Chāzìfú 叉字蝠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/crobat.png",
+   "obs_code": "pokemon_1742544140"
+ },
+ {
+   "code": "Chinchou",
+   "en": "Chinchou",
+   "de": "Lampi",
+   "fr": "Loupio",
+   "ja": "Chonchie チョンチー",
+   "ko": "Ch'oragi 초라기",
+   "zh": "Dēnglóngyú 燈籠魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chinchou.png",
+   "obs_code": "pokemon_3641110264"
+ },
+ {
+   "code": "Lanturn",
+   "en": "Lanturn",
+   "de": "Lanturn",
+   "fr": "Lanturn",
+   "ja": "Lantern ランターン",
+   "ko": "Raent'ŏn 랜턴",
+   "zh": "Diàndēngguài 電燈怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lanturn.png",
+   "obs_code": "pokemon_3568768123"
+ },
+ {
+   "code": "Pichu",
+   "en": "Pichu",
+   "de": "Pichu",
+   "fr": "Pichu",
+   "ja": "Pichu ピチュー",
+   "ko": "P'ich'yu 피츄",
+   "zh": "Píqiū 皮丘",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pichu.png",
+   "obs_code": "pokemon_184323298"
+ },
+ {
+   "code": "Cleffa",
+   "en": "Cleffa",
+   "de": "Pii",
+   "fr": "Melo",
+   "ja": "Py ピィ",
+   "ko": "Ppi 삐",
+   "zh": "Píbăobăo 皮寶寶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cleffa.png",
+   "obs_code": "pokemon_1301658990"
+ },
+ {
+   "code": "Igglybuff",
+   "en": "Igglybuff",
+   "de": "Fluffeluff",
+   "fr": "Toudoudou",
+   "ja": "Pupurin ププリン",
+   "ko": "P'up'urin 푸푸린",
+   "zh": "Băobăodīng 寶寶丁",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/igglybuff.png",
+   "obs_code": "pokemon_1355257582"
+ },
+ {
+   "code": "Togepi",
+   "en": "Togepi",
+   "de": "Togepi",
+   "fr": "Togepi",
+   "ja": "Togepy トゲピー",
+   "ko": "T'ogep'i 토게피",
+   "zh": "Bōkèbĭ 波克比",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/togepi.png",
+   "obs_code": "pokemon_1640303397"
+ },
+ {
+   "code": "Togetic",
+   "en": "Togetic",
+   "de": "Togetic",
+   "fr": "Togetic",
+   "ja": "Togechick トゲチック",
+   "ko": "T'oget'ik 토게틱",
+   "zh": "Bōkèjīgŭ 波克基古",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/togetic.png",
+   "obs_code": "pokemon_3820741026"
+ },
+ {
+   "code": "Natu",
+   "en": "Natu",
+   "de": "Natu",
+   "fr": "Natu",
+   "ja": "Naty ネイティ",
+   "ko": "Neit'i 네이티",
+   "zh": "Tiānránquè 天然雀",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/natu.png",
+   "obs_code": "pokemon_2087971979"
+ },
+ {
+   "code": "Xatu",
+   "en": "Xatu",
+   "de": "Xatu",
+   "fr": "Xatu",
+   "ja": "Natio ネイティオ",
+   "ko": "Neit'io 네이티오",
+   "zh": "Tiānránniăo 天然鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/xatu.png",
+   "obs_code": "pokemon_2087971997"
+ },
+ {
+   "code": "Mareep",
+   "en": "Mareep",
+   "de": "Voltilamm",
+   "fr": "Wattouat",
+   "ja": "Merriep メリープ",
+   "ko": "Merip'ŭ 메리프",
+   "zh": "Miēlìyáng 咩利羊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mareep.png",
+   "obs_code": "pokemon_1894494859"
+ },
+ {
+   "code": "Flaaffy",
+   "en": "Flaaffy",
+   "de": "Waaty",
+   "fr": "Lainergie",
+   "ja": "Mokoko モココ",
+   "ko": "Posongsong 보송송",
+   "zh": "Miánmián 綿綿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/flaaffy.png",
+   "obs_code": "pokemon_935656822"
+ },
+ {
+   "code": "Ampharos",
+   "en": "Ampharos",
+   "de": "Ampharos",
+   "fr": "Pharamp",
+   "ja": "Denryu デンリュウ",
+   "ko": "Chŏllyong 전룡",
+   "zh": "Diànlóng 電龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ampharos.png",
+   "obs_code": "pokemon_902499358"
+ },
+ {
+   "code": "Bellossom",
+   "en": "Bellossom",
+   "de": "Blubella",
+   "fr": "Joliflor",
+   "ja": "Kireihana キレイハナ",
+   "ko": "Arŭk'o 아르코",
+   "zh": "Měilìhuā 美麗花",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bellossom.png",
+   "obs_code": "pokemon_744947567"
+ },
+ {
+   "code": "Marill",
+   "en": "Marill",
+   "de": "Marill",
+   "fr": "Marill",
+   "ja": "Maril マリル",
+   "ko": "Maril 마릴",
+   "zh": "Mǎlìlù 瑪力露",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/marill.png",
+   "obs_code": "pokemon_1423721362"
+ },
+ {
+   "code": "Azumarill",
+   "en": "Azumarill",
+   "de": "Azumarill",
+   "fr": "Azumarill",
+   "ja": "Marilli マリルリ",
+   "ko": "Marilli 마릴리",
+   "zh": "Mǎlìlùlì 瑪力露麗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/azumarill.png",
+   "obs_code": "pokemon_2624113404"
+ },
+ {
+   "code": "Sudowoodo",
+   "en": "Sudowoodo",
+   "de": "Mogelbaum",
+   "fr": "Simularbre",
+   "ja": "Usokkie ウソッキー",
+   "ko": "Kkojimo 꼬지모",
+   "zh": "Húshuōshù 胡說樹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sudowoodo.png",
+   "obs_code": "pokemon_87391092"
+ },
+ {
+   "code": "Politoed",
+   "en": "Politoed",
+   "de": "Quaxo",
+   "fr": "Tarpaud",
+   "ja": "Nyorotono ニョロトノ",
+   "ko": "Wangguri 왕구리",
+   "zh": "Niúwājūn 牛蛙君",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/politoed.png",
+   "obs_code": "pokemon_1268321637"
+ },
+ {
+   "code": "Hoppip",
+   "en": "Hoppip",
+   "de": "Hoppspross",
+   "fr": "Granivol",
+   "ja": "Hanecco ハネッコ",
+   "ko": "T'ongt'ongk'o 통통코",
+   "zh": "Jiànzǐcǎo 毽子草",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hoppip.png",
+   "obs_code": "pokemon_1907798843"
+ },
+ {
+   "code": "Skiploom",
+   "en": "Skiploom",
+   "de": "Hubelupf",
+   "fr": "Floravol",
+   "ja": "Popocco ポポッコ",
+   "ko": "Tuk'o 두코",
+   "zh": "Jiànzǐhuā 毽子花",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skiploom.png",
+   "obs_code": "pokemon_3084934757"
+ },
+ {
+   "code": "Jumpluff",
+   "en": "Jumpluff",
+   "de": "Papungha",
+   "fr": "Cotovol",
+   "ja": "Watacco ワタッコ",
+   "ko": "Somsomk'o 솜솜코",
+   "zh": "Jiànzǐmián 毽子綿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jumpluff.png",
+   "obs_code": "pokemon_2781230238"
+ },
+ {
+   "code": "Aipom",
+   "en": "Aipom",
+   "de": "Griffel",
+   "fr": "Capumain",
+   "ja": "Eipam エイパム",
+   "ko": "Hudin 에이팜",
+   "zh": "Chángwěiguàishǒu 長尾怪手",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aipom.png",
+   "obs_code": "pokemon_174594591"
+ },
+ {
+   "code": "Sunkern",
+   "en": "Sunkern",
+   "de": "Sonnkern",
+   "fr": "Tournegrin",
+   "ja": "Himanuts ヒマナッツ",
+   "ko": "Haenŏch'ŭ 해너츠",
+   "zh": "Xiàngrìzhǒngzǐ 向日種子",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sunkern.png",
+   "obs_code": "pokemon_3587205471"
+ },
+ {
+   "code": "Sunflora",
+   "en": "Sunflora",
+   "de": "Sonnflora",
+   "fr": "Heliatronc",
+   "ja": "Kimawari キマワリ",
+   "ko": "Haerumi 해루미",
+   "zh": "Xiàngrìhuāguài 向日花怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sunflora.png",
+   "obs_code": "pokemon_181436603"
+ },
+ {
+   "code": "Yanma",
+   "en": "Yanma",
+   "de": "Yanma",
+   "fr": "Yanma",
+   "ja": "Yanyanma ヤンヤンマ",
+   "ko": "Wangjari 왕자리",
+   "zh": "Yángyángmǎ 陽陽瑪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/yanma.png",
+   "obs_code": "pokemon_169911647"
+ },
+ {
+   "code": "Wooper",
+   "en": "Wooper",
+   "de": "Felino",
+   "fr": "Axoloto",
+   "ja": "Upah ウパー",
+   "ko": "Up'a 우파",
+   "zh": "Wūbō 烏波",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wooper.png",
+   "obs_code": "pokemon_2123764021"
+ },
+ {
+   "code": "Quagsire",
+   "en": "Quagsire",
+   "de": "Morlord",
+   "fr": "Maraiste",
+   "ja": "Nuoh ヌオー",
+   "ko": "Nuo 누오",
+   "zh": "Zhǎowáng 沼王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/quagsire.png",
+   "obs_code": "pokemon_1578860042"
+ },
+ {
+   "code": "Espeon",
+   "en": "Espeon",
+   "de": "Psiana",
+   "fr": "Mentali",
+   "ja": "Eifie エーフィ",
+   "ko": "Ebŭi 에브이",
+   "zh": "Tàiyángjīnglíng 太陽精靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/espeon.png",
+   "obs_code": "pokemon_1647572359"
+ },
+ {
+   "code": "Umbreon",
+   "en": "Umbreon",
+   "de": "Nachtara",
+   "fr": "Noctali",
+   "ja": "Blacky ブラッキー",
+   "ko": "Bŭllaek'i 블래키",
+   "zh": "Yuèjīnglíng 月精靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/umbreon.png",
+   "obs_code": "pokemon_2830512137"
+ },
+ {
+   "code": "Murkrow",
+   "en": "Murkrow",
+   "de": "Kramurx",
+   "fr": "Cornebre",
+   "ja": "Yamikarasu ヤミカラス",
+   "ko": "Nirou 니로우",
+   "zh": "Hēi'ànyā 黑暗鴉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/murkrow.png",
+   "obs_code": "pokemon_2332650030"
+ },
+ {
+   "code": "Slowking",
+   "en": "Slowking",
+   "de": "Laschoking",
+   "fr": "Roigada",
+   "ja": "Yadoking ヤドキング",
+   "ko": "Yadok'ing 야도킹",
+   "zh": "Hémǎwáng 河馬王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slowking.png",
+   "obs_code": "pokemon_832856169"
+ },
+ {
+   "code": "Misdreavus",
+   "en": "Misdreavus",
+   "de": "Traunfugil",
+   "fr": "Feuforeve",
+   "ja": "Muma ムウマ",
+   "ko": "Muuma 무우마",
+   "zh": "Mèngyāo 夢妖",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/misdreavus.png",
+   "obs_code": "pokemon_1760655216"
+ },
+ {
+   "code": "Unown",
+   "en": "Unown",
+   "de": "Icognito",
+   "fr": "Zarbi",
+   "ja": "Unknown アンノーン",
+   "ko": "Annong 안농",
+   "zh": "Wèizhītúténg 未知圖騰",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/unown.png",
+   "obs_code": "pokemon_180937064"
+ },
+ {
+   "code": "Wobbuffet",
+   "en": "Wobbuffet",
+   "de": "Woingenau",
+   "fr": "Qulbutoke",
+   "ja": "Sonans ソーナンス",
+   "ko": "Majayong 마자용",
+   "zh": "Guǒránwēng 果然翁",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wobbuffet.png",
+   "obs_code": "pokemon_3005062745"
+ },
+ {
+   "code": "Girafarig",
+   "en": "Girafarig",
+   "de": "Girafarig",
+   "fr": "Girafarig",
+   "ja": "Kirinriki キリンリキ",
+   "ko": "K'iringk'i 키링키",
+   "zh": "Qílínqí 麒麟奇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/girafarig.png",
+   "obs_code": "pokemon_1468473283"
+ },
+ {
+   "code": "Pineco",
+   "en": "Pineco",
+   "de": "Tannza",
+   "fr": "Pomdepik",
+   "ja": "Kunugidama クヌギダマ",
+   "ko": "P'ik'on 피콘",
+   "zh": "榛果球 榛果球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pineco.png",
+   "obs_code": "pokemon_1696169979"
+ },
+ {
+   "code": "Forretress",
+   "en": "Forretress",
+   "de": "Forstellka",
+   "fr": "Foretress",
+   "ja": "Foretos フォレトス",
+   "ko": "Ssok'on 쏘콘",
+   "zh": "Fúliètuōsī 佛烈托斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/forretress.png",
+   "obs_code": "pokemon_125015082"
+ },
+ {
+   "code": "Dunsparce",
+   "en": "Dunsparce",
+   "de": "Dummisel",
+   "fr": "Insolourdo",
+   "ja": "Nokocchi ノコッチ",
+   "ko": "Nogoch'i 노고치",
+   "zh": "Tǔlóngdìdì 土龍弟弟",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dunsparce.png",
+   "obs_code": "pokemon_1631287756"
+ },
+ {
+   "code": "Gligar",
+   "en": "Gligar",
+   "de": "Skorgla",
+   "fr": "Scorplane",
+   "ja": "Gliger グライガー",
+   "ko": "Kŭllaigŏ 글라이거",
+   "zh": "Tiānxiē 天蠍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gligar.png",
+   "obs_code": "pokemon_2128968691"
+ },
+ {
+   "code": "Steelix",
+   "en": "Steelix",
+   "de": "Stahlos",
+   "fr": "Steelix",
+   "ja": "Haganeil ハガネール",
+   "ko": "Kangch'ŏlton 강철톤",
+   "zh": "Dàgāngshé 大鋼蛇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/steelix.png",
+   "obs_code": "pokemon_3966719711"
+ },
+ {
+   "code": "Snubbull",
+   "en": "Snubbull",
+   "de": "Snubbull",
+   "fr": "Snubbull",
+   "ja": "Bulu ブルー",
+   "ko": "Pŭllu 블루",
+   "zh": "Bùlú 布盧",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/snubbull.png",
+   "obs_code": "pokemon_87043000"
+ },
+ {
+   "code": "Granbull",
+   "en": "Granbull",
+   "de": "Granbull",
+   "fr": "Granbull",
+   "ja": "Granbulu グランブル",
+   "ko": "Kŭrangbŭllu 그랑블루",
+   "zh": "Bùlúhuáng 布盧皇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/granbull.png",
+   "obs_code": "pokemon_87486632"
+ },
+ {
+   "code": "Qwilfish",
+   "en": "Qwilfish",
+   "de": "Baldorfish",
+   "fr": "Qwilfish",
+   "ja": "Harysen ハリーセン",
+   "ko": "Ch'imbaru 침바루",
+   "zh": "Qiānzhēnyú 千針魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/qwilfish.png",
+   "obs_code": "pokemon_1348720274"
+ },
+ {
+   "code": "Scizor",
+   "en": "Scizor",
+   "de": "Scherox",
+   "fr": "Cizayox",
+   "ja": "Hassam ハッサム",
+   "ko": "Hassam 핫삼",
+   "zh": "Jùqiántángláng 巨鉗螳螂",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scizor.png",
+   "obs_code": "pokemon_2125922811"
+ },
+ {
+   "code": "Shuckle",
+   "en": "Shuckle",
+   "de": "Pottrott",
+   "fr": "Caratroc",
+   "ja": "Tsubotsubo ツボツボ",
+   "ko": "Tandanji 단단지",
+   "zh": "Húhú 壺壺",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shuckle.png",
+   "obs_code": "pokemon_4118086058"
+ },
+ {
+   "code": "Heracross",
+   "en": "Heracross",
+   "de": "Skaraborn",
+   "fr": "Scarhino",
+   "ja": "Heracros ヘラクロス",
+   "ko": "Herak'ŭrosŭ 헤라크로스",
+   "zh": "Hèlākèluósī 赫拉剋羅斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/heracross.png",
+   "obs_code": "pokemon_4000164773"
+ },
+ {
+   "code": "Sneasel",
+   "en": "Sneasel",
+   "de": "Sniebel",
+   "fr": "Farfuret",
+   "ja": "Nyula ニューラ",
+   "ko": "P'op'uni 포푸니",
+   "zh": "Niǔlā 狃拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sneasel.png",
+   "obs_code": "pokemon_101555526"
+ },
+ {
+   "code": "Teddiursa",
+   "en": "Teddiursa",
+   "de": "Teddiursa",
+   "fr": "Teddiursa",
+   "ja": "Himeguma ヒメグマ",
+   "ko": "Kkamjigom 깜지곰",
+   "zh": "Xióngbǎobǎo 熊寶寶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/teddiursa.png",
+   "obs_code": "pokemon_1972940072"
+ },
+ {
+   "code": "Ursaring",
+   "en": "Ursaring",
+   "de": "Ursaring",
+   "fr": "Ursaring",
+   "ja": "Ringuma リングマ",
+   "ko": "Ringgom 링곰",
+   "zh": "Quānquānxióng 圈圈熊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ursaring.png",
+   "obs_code": "pokemon_840785442"
+ },
+ {
+   "code": "Slugma",
+   "en": "Slugma",
+   "de": "Schneckmag",
+   "fr": "Limagna",
+   "ja": "Magmag マグマッグ",
+   "ko": "Magŭmagŭ 마그마그",
+   "zh": "Róngyánchóng 熔岩蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slugma.png",
+   "obs_code": "pokemon_1312169476"
+ },
+ {
+   "code": "Magcargo",
+   "en": "Magcargo",
+   "de": "Magcargo",
+   "fr": "Volcaropod",
+   "ja": "Magcargot マグカルゴ",
+   "ko": "Magŭk'arŭgo 마그카르고",
+   "zh": "Róngyánwōniú 熔岩蝸牛",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magcargo.png",
+   "obs_code": "pokemon_1834930998"
+ },
+ {
+   "code": "Swinub",
+   "en": "Swinub",
+   "de": "Quiekel",
+   "fr": "Marcacrin",
+   "ja": "Urimoo ウリムー",
+   "ko": "Kkukkuri 꾸꾸리",
+   "zh": "Xiǎoshānzhū 小山豬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swinub.png",
+   "obs_code": "pokemon_1517351921"
+ },
+ {
+   "code": "Piloswine",
+   "en": "Piloswine",
+   "de": "Keifel",
+   "fr": "Cochignon",
+   "ja": "Inomoo イノムー",
+   "ko": "Mekkuri 메꾸리",
+   "zh": "Chángmáozhū 長毛豬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/piloswine.png",
+   "obs_code": "pokemon_3771589817"
+ },
+ {
+   "code": "Corsola",
+   "en": "Corsola",
+   "de": "Corasonn",
+   "fr": "Corayon",
+   "ja": "Sunnygo サニーゴ",
+   "ko": "K'osanho 코산호",
+   "zh": "Tàiyángshānhú 太陽珊瑚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/corsola.png",
+   "obs_code": "pokemon_386227274"
+ },
+ {
+   "code": "Remoraid",
+   "en": "Remoraid",
+   "de": "Remoraid",
+   "fr": "Remoraid",
+   "ja": "Teppouo テッポウオ",
+   "ko": "Ch'ongŏ 총어",
+   "zh": "Tiěpàoyú 鐵炮魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/remoraid.png",
+   "obs_code": "pokemon_2049306862"
+ },
+ {
+   "code": "Octillery",
+   "en": "Octillery",
+   "de": "Octillery",
+   "fr": "Octillery",
+   "ja": "Okutank オクタン",
+   "ko": "Taep'omuno 대포무노",
+   "zh": "Zhāngyútǒng 章魚桶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/octillery.png",
+   "obs_code": "pokemon_3493892698"
+ },
+ {
+   "code": "Delibird",
+   "en": "Delibird",
+   "de": "Botogel",
+   "fr": "Cadoizo",
+   "ja": "Delibird デリバード",
+   "ko": "Tillibŏdŭ 딜리버드",
+   "zh": "Xìnshǐniǎo 信使鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/delibird.png",
+   "obs_code": "pokemon_212992572"
+ },
+ {
+   "code": "Mantine",
+   "en": "Mantine",
+   "de": "Mantax",
+   "fr": "Demanta",
+   "ja": "Mantain マンタイン",
+   "ko": "Mant'ain 만타인",
+   "zh": "Jùchìfēiyú 巨翅飛魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mantine.png",
+   "obs_code": "pokemon_4038055089"
+ },
+ {
+   "code": "Skarmory",
+   "en": "Skarmory",
+   "de": "Panzaeron",
+   "fr": "Airmure",
+   "ja": "Airmd エアームド",
+   "ko": "Mujangjo 무장조",
+   "zh": "Kuījiǎniǎo 盔甲鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skarmory.png",
+   "obs_code": "pokemon_1839177191"
+ },
+ {
+   "code": "Houndour",
+   "en": "Houndour",
+   "de": "Hunduster",
+   "fr": "Malosse",
+   "ja": "Delvil デルビル",
+   "ko": "Delbil 델빌",
+   "zh": "Dàilǔbǐ 戴魯比",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/houndour.png",
+   "obs_code": "pokemon_4019940181"
+ },
+ {
+   "code": "Houndoom",
+   "en": "Houndoom",
+   "de": "Hundemon",
+   "fr": "Demolosse",
+   "ja": "Hellgar ヘルガー",
+   "ko": "Helga 헬가",
+   "zh": "Hēilǔjiā 黑魯加",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/houndoom.png",
+   "obs_code": "pokemon_3093640368"
+ },
+ {
+   "code": "Kingdra",
+   "en": "Kingdra",
+   "de": "Seedraking",
+   "fr": "Hyporoi",
+   "ja": "Kingdra キングドラ",
+   "ko": "K'ingdŭra 킹드라",
+   "zh": "Cìlóngwáng 刺龍王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kingdra.png",
+   "obs_code": "pokemon_776135513"
+ },
+ {
+   "code": "Phanpy",
+   "en": "Phanpy",
+   "de": "Phanpy",
+   "fr": "Phanpy",
+   "ja": "Gomazou ゴマゾウ",
+   "ko": "K'ok'ori 코코리",
+   "zh": "Xiǎoxiǎoxiàng 小小象",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/phanpy.png",
+   "obs_code": "pokemon_2228474235"
+ },
+ {
+   "code": "Donphan",
+   "en": "Donphan",
+   "de": "Donphan",
+   "fr": "Donphan",
+   "ja": "Donfan ドンファン",
+   "ko": "K'origap 코리갑",
+   "zh": "Dùnjiǎ 頓甲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/donphan.png",
+   "obs_code": "pokemon_3213426967"
+ },
+ {
+   "code": "Porygon2",
+   "en": "Porygon2",
+   "de": "Porygon2",
+   "fr": "Porygon2",
+   "ja": "Porygon2 ポリゴン2",
+   "ko": "P'olligon2 폴리곤2",
+   "zh": "3D-Lóng II 3D龍II",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/porygon2.png",
+   "obs_code": "pokemon_2524580645"
+ },
+ {
+   "code": "Stantler",
+   "en": "Stantler",
+   "de": "Damhirplex",
+   "fr": "Cerfrousse",
+   "ja": "Odoshishi オドシシ",
+   "ko": "Norak'i 노라키",
+   "zh": "Jīngjiǎolù 驚角鹿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stantler.png",
+   "obs_code": "pokemon_3152632706"
+ },
+ {
+   "code": "Smeargle",
+   "en": "Smeargle",
+   "de": "Farbeagle",
+   "fr": "Queulorior",
+   "ja": "Doble ドーブル",
+   "ko": "Rubŭdo 루브도",
+   "zh": "Tútúquǎn 圖圖犬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/smeargle.png",
+   "obs_code": "pokemon_2926893187"
+ },
+ {
+   "code": "Tyrogue",
+   "en": "Tyrogue",
+   "de": "Rabauz",
+   "fr": "Debugant",
+   "ja": "Balkie バルキー",
+   "ko": "Paeruk'i 배루키",
+   "zh": "Bā'ěrláng 巴爾郎",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tyrogue.png",
+   "obs_code": "pokemon_97755874"
+ },
+ {
+   "code": "Hitmontop",
+   "en": "Hitmontop",
+   "de": "Kapoera",
+   "fr": "Kapoera",
+   "ja": "Kapoerer カポエラー",
+   "ko": "K'ap'oera 카포에라",
+   "zh": "Kēbōlǎng 柯波朗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hitmontop.png",
+   "obs_code": "pokemon_2586826103"
+ },
+ {
+   "code": "Smoochum",
+   "en": "Smoochum",
+   "de": "Kussilla",
+   "fr": "Lippouti",
+   "ja": "Muchul ムチュール",
+   "ko": "Ppoppora 뽀뽀라",
+   "zh": "Míchúnwá 迷唇娃",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/smoochum.png",
+   "obs_code": "pokemon_440467624"
+ },
+ {
+   "code": "Elekid",
+   "en": "Elekid",
+   "de": "Elekid",
+   "fr": "Elekid",
+   "ja": "Elekid エレキッド",
+   "ko": "Erek'idŭ 에레키드",
+   "zh": "Diànjíguài 電擊怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/elekid.png",
+   "obs_code": "pokemon_1125535919"
+ },
+ {
+   "code": "Magby",
+   "en": "Magby",
+   "de": "Magby",
+   "fr": "Magby",
+   "ja": "Buby ブビィ",
+   "ko": "Magŭbi 마그비",
+   "zh": "Xiǎoyāzuǐlóng 小鴨嘴龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magby.png",
+   "obs_code": "pokemon_198190773"
+ },
+ {
+   "code": "Miltank",
+   "en": "Miltank",
+   "de": "Miltank",
+   "fr": "Ecremeuh",
+   "ja": "Miltank ミルタンク",
+   "ko": "Miltaengk'ŭ 밀탱크",
+   "zh": "Dànǎiguàn 大奶罐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/miltank.png",
+   "obs_code": "pokemon_276710205"
+ },
+ {
+   "code": "Blissey",
+   "en": "Blissey",
+   "de": "Heiteira",
+   "fr": "Leuphorie",
+   "ja": "Happinas ハピナス",
+   "ko": "Haep'inasŭ 해피너스",
+   "zh": "Xìngfúdàn 幸福蛋",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/blissey.png",
+   "obs_code": "pokemon_945787358"
+ },
+ {
+   "code": "Raikou",
+   "en": "Raikou",
+   "de": "Raikou",
+   "fr": "Raikou",
+   "ja": "Raikou ライコウ",
+   "ko": "Raik'o 라이코",
+   "zh": "Léigōng 雷公",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/raikou.png",
+   "obs_code": "pokemon_1797678382"
+ },
+ {
+   "code": "Entei",
+   "en": "Entei",
+   "de": "Entei",
+   "fr": "Entei",
+   "ja": "Entei エンテイ",
+   "ko": "Aent'ei 앤테이",
+   "zh": "Yándì 炎帝",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/entei.png",
+   "obs_code": "pokemon_179130998"
+ },
+ {
+   "code": "Suicune",
+   "en": "Suicune",
+   "de": "Suicune",
+   "fr": "Suicune",
+   "ja": "Suicune スイクン",
+   "ko": "Sŭik'un 스이쿤",
+   "zh": "Shuǐjūn 水君",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/suicune.png",
+   "obs_code": "pokemon_4061426711"
+ },
+ {
+   "code": "Larvitar",
+   "en": "Larvitar",
+   "de": "Larvitar",
+   "fr": "Embrylex",
+   "ja": "Yogiras ヨーギラス",
+   "ko": "Aebŏrasŭ 애버라스",
+   "zh": "Yóujīlā 由基拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/larvitar.png",
+   "obs_code": "pokemon_2804138018"
+ },
+ {
+   "code": "Pupitar",
+   "en": "Pupitar",
+   "de": "Pupitar",
+   "fr": "Ymphect",
+   "ja": "Sanagiras サナギラス",
+   "ko": "Tegirasŭ 데기라스",
+   "zh": "Shājīlā 沙基拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pupitar.png",
+   "obs_code": "pokemon_1516631934"
+ },
+ {
+   "code": "Tyranitar",
+   "en": "Tyranitar",
+   "de": "Despotar",
+   "fr": "Tyranocif",
+   "ja": "Bangiras バンギラス",
+   "ko": "Magirasŭ 마기라스",
+   "zh": "Bānjīlā 班吉拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tyranitar.png",
+   "obs_code": "pokemon_2314478555"
+ },
+ {
+   "code": "Lugia",
+   "en": "Lugia",
+   "de": "Lugia",
+   "fr": "Lugia",
+   "ja": "Lugia ルギア",
+   "ko": "Rugia 루기아",
+   "zh": "Luòqíyà 洛奇亞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lugia.png",
+   "obs_code": "pokemon_170048531"
+ },
+ {
+   "code": "Ho-oh",
+   "en": "Ho-oh",
+   "de": "Ho-oh",
+   "fr": "Ho-Oh",
+   "ja": "Houou ホウオウ",
+   "ko": "Ch'ilsaekjo 칠색조",
+   "zh": "Fèngwáng 鳳王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ho-oh.png",
+   "obs_code": "pokemon_177791304"
+ },
+ {
+   "code": "Celebi",
+   "en": "Celebi",
+   "de": "Celebi",
+   "fr": "Celebi",
+   "ja": "Celebi セレビィ",
+   "ko": "Serebi 세레비",
+   "zh": "Xuělābǐ 雪拉比",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/celebi.png",
+   "obs_code": "pokemon_1619088929"
+ },
+ {
+   "code": "Treecko",
+   "en": "Treecko",
+   "de": "Geckarbor",
+   "fr": "Arcko",
+   "ja": "Kimori キモリ",
+   "ko": "Namujigi 나무지기",
+   "zh": "Mùshǒugōng 木守宮",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/treecko.png",
+   "obs_code": "pokemon_4123740036"
+ },
+ {
+   "code": "Grovyle",
+   "en": "Grovyle",
+   "de": "Reptain",
+   "fr": "Massko",
+   "ja": "Juptile ジュプトル",
+   "ko": "Namudori 나무돌이",
+   "zh": "Sēnlínxīyì 森林蜥蜴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/grovyle.png",
+   "obs_code": "pokemon_4129480537"
+ },
+ {
+   "code": "Sceptile",
+   "en": "Sceptile",
+   "de": "Gewaldro",
+   "fr": "Jungko",
+   "ja": "Jukain ジュカイン",
+   "ko": "Namuk'ing 나무킹",
+   "zh": "Xīyìwáng 蜥蜴王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sceptile.png",
+   "obs_code": "pokemon_2541761332"
+ },
+ {
+   "code": "Torchic",
+   "en": "Torchic",
+   "de": "Flemmli",
+   "fr": "Poussifeu",
+   "ja": "Achamo アチャモ",
+   "ko": "Ach'amo 아차모",
+   "zh": "Huǒzhìjī 火稚雞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/torchic.png",
+   "obs_code": "pokemon_3796694957"
+ },
+ {
+   "code": "Combusken",
+   "en": "Combusken",
+   "de": "Jungglut",
+   "fr": "Galifeu",
+   "ja": "Wakasyamo ワカシャモ",
+   "ko": "Yŏngchi'ik'o 영치코",
+   "zh": "Lìzhuàngjī 力壯雞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/combusken.png",
+   "obs_code": "pokemon_3140572064"
+ },
+ {
+   "code": "Blaziken",
+   "en": "Blaziken",
+   "de": "Lohgock",
+   "fr": "Brasegali",
+   "ja": "Bursyamo バシャーモ",
+   "ko": "Pŏnch'ik'o 번치코",
+   "zh": "Huǒyànjī 火焰雞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/blaziken.png",
+   "obs_code": "pokemon_3854056633"
+ },
+ {
+   "code": "Mudkip",
+   "en": "Mudkip",
+   "de": "Hydropi",
+   "fr": "Gobou",
+   "ja": "Mizugorou ミズゴロウ",
+   "ko": "Multchang'i 물짱이",
+   "zh": "Shuǐyuèyú 水躍魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mudkip.png",
+   "obs_code": "pokemon_1908241995"
+ },
+ {
+   "code": "Marshtomp",
+   "en": "Marshtomp",
+   "de": "Moorabbel",
+   "fr": "Flobio",
+   "ja": "Numacraw ヌマクロー",
+   "ko": "Nŭptchang'i 늪짱이",
+   "zh": "Zhǎoyuèyú 沼躍魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/marshtomp.png",
+   "obs_code": "pokemon_342331942"
+ },
+ {
+   "code": "Swampert",
+   "en": "Swampert",
+   "de": "Sumpex",
+   "fr": "Laggron",
+   "ja": "Laglarge ラグラージ",
+   "ko": "Taetchang'i 대짱이",
+   "zh": "Jùzhǎoguài 巨沼怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swampert.png",
+   "obs_code": "pokemon_691597886"
+ },
+ {
+   "code": "Poochyena",
+   "en": "Poochyena",
+   "de": "Fiffyen",
+   "fr": "Medhyena",
+   "ja": "Pochiena ポチエナ",
+   "ko": "P'och'yana 포차나",
+   "zh": "Tǔlángquǎn 土狼犬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/poochyena.png",
+   "obs_code": "pokemon_3758673133"
+ },
+ {
+   "code": "Mightyena",
+   "en": "Mightyena",
+   "de": "Magnayen",
+   "fr": "Grahyena",
+   "ja": "Guraena グラエナ",
+   "ko": "Gŭraëna 그라에나",
+   "zh": "Dàlángquǎn 大狼犬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mightyena.png",
+   "obs_code": "pokemon_3725731401"
+ },
+ {
+   "code": "Zigzagoon",
+   "en": "Zigzagoon",
+   "de": "Zigzachs",
+   "fr": "Zigzaton",
+   "ja": "Ziguzaguma ジグザグマ",
+   "ko": "Chigŭjeguri 지그제구리",
+   "zh": "Shéwénxióng 蛇紋熊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zigzagoon.png",
+   "obs_code": "pokemon_2788681763"
+ },
+ {
+   "code": "Linoone",
+   "en": "Linoone",
+   "de": "Geradaks",
+   "fr": "Lineon",
+   "ja": "Massuguma マッスグマ",
+   "ko": "Chikkuri 직구리",
+   "zh": "Zhíchōngxióng 直衝熊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/linoone.png",
+   "obs_code": "pokemon_4035754565"
+ },
+ {
+   "code": "Wurmple",
+   "en": "Wurmple",
+   "de": "Waumpel",
+   "fr": "Chenipotte",
+   "ja": "Kemusso ケムッソ",
+   "ko": "Kaemuso 개무소",
+   "zh": "Cìwěichóng 刺尾蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wurmple.png",
+   "obs_code": "pokemon_4140378177"
+ },
+ {
+   "code": "Silcoon",
+   "en": "Silcoon",
+   "de": "Schaloko",
+   "fr": "Armulys",
+   "ja": "Karasalis カラサリス",
+   "ko": "Silk'un 실쿤",
+   "zh": "Jiǎkéyǒng 甲殼蛹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/silcoon.png",
+   "obs_code": "pokemon_2846005502"
+ },
+ {
+   "code": "Beautifly",
+   "en": "Beautifly",
+   "de": "Papinella",
+   "fr": "Charmillon",
+   "ja": "Agehunt アゲハント",
+   "ko": "Pyut'ipŭllai 뷰티플라이",
+   "zh": "Shòulièfèngdié 狩獵鳳蝶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/beautifly.png",
+   "obs_code": "pokemon_3157102456"
+ },
+ {
+   "code": "Cascoon",
+   "en": "Cascoon",
+   "de": "Panekon",
+   "fr": "Blindalys",
+   "ja": "Mayuld マユルド",
+   "ko": "K'asŭk'un 카스쿤",
+   "zh": "Dùnjiǎjiǎn 盾甲繭",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cascoon.png",
+   "obs_code": "pokemon_2846023737"
+ },
+ {
+   "code": "Dustox",
+   "en": "Dustox",
+   "de": "Pudox",
+   "fr": "Papinox",
+   "ja": "Dokucale ドクケイル",
+   "ko": "Tokk'eil 독케일",
+   "zh": "Dúfěndié 毒粉蝶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dustox.png",
+   "obs_code": "pokemon_2195075620"
+ },
+ {
+   "code": "Lotad",
+   "en": "Lotad",
+   "de": "Loturzel",
+   "fr": "Nenupiot",
+   "ja": "Hassboh ハスボー",
+   "ko": "Yŏnkkotmon 연꽃몬",
+   "zh": "Liányètóngzǐ 蓮葉童子",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lotad.png",
+   "obs_code": "pokemon_163995415"
+ },
+ {
+   "code": "Lombre",
+   "en": "Lombre",
+   "de": "Lombrero",
+   "fr": "Lombre",
+   "ja": "Hasubrero ハスブレロ",
+   "ko": "Rotosŭ 로토스",
+   "zh": "Liánmàoxiǎotóng 蓮帽小童",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lombre.png",
+   "obs_code": "pokemon_1168708702"
+ },
+ {
+   "code": "Ludicolo",
+   "en": "Ludicolo",
+   "de": "Kappalores",
+   "fr": "Ludicolo",
+   "ja": "Runpappa ルンパッパ",
+   "ko": "Rop'ap'a 로파파",
+   "zh": "Lètiānhétóng 樂天河童",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ludicolo.png",
+   "obs_code": "pokemon_2516491678"
+ },
+ {
+   "code": "Seedot",
+   "en": "Seedot",
+   "de": "Samurzel",
+   "fr": "Grainipiot",
+   "ja": "Taneboh タネボー",
+   "ko": "Tot'oring 도토링",
+   "zh": "Xiàngshíguǒ 橡實果",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seedot.png",
+   "obs_code": "pokemon_1754185897"
+ },
+ {
+   "code": "Nuzleaf",
+   "en": "Nuzleaf",
+   "de": "Blanas",
+   "fr": "Pifeuil",
+   "ja": "Konohana コノハナ",
+   "ko": "Ipsaek'o 잎새코",
+   "zh": "Chángbíyè 長鼻葉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nuzleaf.png",
+   "obs_code": "pokemon_1484305418"
+ },
+ {
+   "code": "Shiftry",
+   "en": "Shiftry",
+   "de": "Tengulist",
+   "fr": "Tengalice",
+   "ja": "Dirteng ダーテング",
+   "ko": "Tat'aenggu 다탱구",
+   "zh": "Jiǎohuátiāngǒu 狡猾天狗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shiftry.png",
+   "obs_code": "pokemon_473251662"
+ },
+ {
+   "code": "Taillow",
+   "en": "Taillow",
+   "de": "Schwalbini",
+   "fr": "Nirondelle",
+   "ja": "Subame スバメ",
+   "ko": "T'eillo 테일로",
+   "zh": "Àogǔyàn 傲骨燕",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/taillow.png",
+   "obs_code": "pokemon_2340483009"
+ },
+ {
+   "code": "Swellow",
+   "en": "Swellow",
+   "de": "Schwalboss",
+   "fr": "Heledelle",
+   "ja": "Ohsubame オオスバメ",
+   "ko": "Sŭwallo 스왈로",
+   "zh": "Dàwángyàn 大王燕",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swellow.png",
+   "obs_code": "pokemon_2340486940"
+ },
+ {
+   "code": "Wingull",
+   "en": "Wingull",
+   "de": "Wingull",
+   "fr": "Goelise",
+   "ja": "Camome キャモメ",
+   "ko": "Kalmomae 갈모매",
+   "zh": "Chángchì'ōu 長翅鷗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wingull.png",
+   "obs_code": "pokemon_4037696903"
+ },
+ {
+   "code": "Pelipper",
+   "en": "Pelipper",
+   "de": "Pelipper",
+   "fr": "Bekipan",
+   "ja": "Pelipper ペリッパー",
+   "ko": "P'aerip'ŏ 패리퍼",
+   "zh": "Dàzuǐ'ōu 大嘴鷗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pelipper.png",
+   "obs_code": "pokemon_2100139842"
+ },
+ {
+   "code": "Ralts",
+   "en": "Ralts",
+   "de": "Trasla",
+   "fr": "Tarsal",
+   "ja": "Ralts ラルトス",
+   "ko": "Ralt'osŭ 랄토스",
+   "zh": "Lālǔlāsī 拉魯拉絲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ralts.png",
+   "obs_code": "pokemon_195044669"
+ },
+ {
+   "code": "Kirlia",
+   "en": "Kirlia",
+   "de": "Kirlia",
+   "fr": "Kirlia",
+   "ja": "Kirlia キルリア",
+   "ko": "K'illia 킬리아",
+   "zh": "Qílǔlì'ān 奇魯莉安",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kirlia.png",
+   "obs_code": "pokemon_1316384209"
+ },
+ {
+   "code": "Gardevoir",
+   "en": "Gardevoir",
+   "de": "Guardevoir",
+   "fr": "Gardevoir",
+   "ja": "Sirnight サーナイト",
+   "ko": "Kadian 가디언",
+   "zh": "Shānàiduǒ 沙奈朵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gardevoir.png",
+   "obs_code": "pokemon_1801395602"
+ },
+ {
+   "code": "Surskit",
+   "en": "Surskit",
+   "de": "Gehweiher",
+   "fr": "Arakdo",
+   "ja": "Ametama アメタマ",
+   "ko": "Pigusul 비구슬",
+   "zh": "Liūliūtángqiú 溜溜糖球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/surskit.png",
+   "obs_code": "pokemon_1970965684"
+ },
+ {
+   "code": "Masquerain",
+   "en": "Masquerain",
+   "de": "Maskeregen",
+   "fr": "Maskadra",
+   "ja": "Amemoth アメモース",
+   "ko": "Pinabang 비나방",
+   "zh": "Yǔchì'é 雨翅蛾",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/masquerain.png",
+   "obs_code": "pokemon_518097679"
+ },
+ {
+   "code": "Shroomish",
+   "en": "Shroomish",
+   "de": "Knilz",
+   "fr": "Balignon",
+   "ja": "Kinococo キノココ",
+   "ko": "Pŏsŏtkko 버섯꼬",
+   "zh": "Mómógū 蘑蘑菇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shroomish.png",
+   "obs_code": "pokemon_1807930291"
+ },
+ {
+   "code": "Breloom",
+   "en": "Breloom",
+   "de": "Kapilz",
+   "fr": "Chapignon",
+   "ja": "Kinogassa キノガッサ",
+   "ko": "Pŏsŏtmo 버섯모",
+   "zh": "Dǒulìgū 斗笠菇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/breloom.png",
+   "obs_code": "pokemon_1134672945"
+ },
+ {
+   "code": "Slakoth",
+   "en": "Slakoth",
+   "de": "Bummelz",
+   "fr": "Parecool",
+   "ja": "Namakero ナマケロ",
+   "ko": "Keŭllo 게을로",
+   "zh": "Lǎnrénwēng 懶人翁",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slakoth.png",
+   "obs_code": "pokemon_1227788003"
+ },
+ {
+   "code": "Vigoroth",
+   "en": "Vigoroth",
+   "de": "Muntier",
+   "fr": "Vigoroth",
+   "ja": "Yarukimono ヤルキモノ",
+   "ko": "Palbaro 발바로",
+   "zh": "Guòdòngyuán 過動猿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vigoroth.png",
+   "obs_code": "pokemon_1826052467"
+ },
+ {
+   "code": "Slaking",
+   "en": "Slaking",
+   "de": "Letarking",
+   "fr": "Monaflemit",
+   "ja": "Kekking ケッキング",
+   "ko": "Geŭlk'ing 게을킹",
+   "zh": "Qǐngjiàwáng 請假王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slaking.png",
+   "obs_code": "pokemon_2888534256"
+ },
+ {
+   "code": "Nincada",
+   "en": "Nincada",
+   "de": "Nincada",
+   "fr": "Ningale",
+   "ja": "Tutinin ツチニン",
+   "ko": "T'ojungmon 토중몬",
+   "zh": "Tǔjūrěnshì 土居忍士",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nincada.png",
+   "obs_code": "pokemon_70514699"
+ },
+ {
+   "code": "Ninjask",
+   "en": "Ninjask",
+   "de": "Ninjask",
+   "fr": "Ninjask",
+   "ja": "Tekkanin テッカニン",
+   "ko": "Aisŭk'ŭ 아이스크",
+   "zh": "Tiěmiànrěnzhě 鐵面忍者",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ninjask.png",
+   "obs_code": "pokemon_1631494815"
+ },
+ {
+   "code": "Shedinja",
+   "en": "Shedinja",
+   "de": "Ninjatom",
+   "fr": "Munja",
+   "ja": "Nukenin ヌケニン",
+   "ko": "Kkŏpjilmon 껍질몬",
+   "zh": "Tuōkérěnzhě 脫殼忍者",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shedinja.png",
+   "obs_code": "pokemon_2167913587"
+ },
+ {
+   "code": "Whismur",
+   "en": "Whismur",
+   "de": "Flurmel",
+   "fr": "Chuchmur",
+   "ja": "Gonyonyo ゴニョニョ",
+   "ko": "Sogonnyong 소곤룡",
+   "zh": "Gūniūniū 咕妞妞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/whismur.png",
+   "obs_code": "pokemon_770874570"
+ },
+ {
+   "code": "Loudred",
+   "en": "Loudred",
+   "de": "Krakeelo",
+   "fr": "Ramboum",
+   "ja": "Dogohmb ドゴーム",
+   "ko": "Nogongryong 노공룡",
+   "zh": "Hǒubàodàn 吼爆彈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/loudred.png",
+   "obs_code": "pokemon_2655922628"
+ },
+ {
+   "code": "Exploud",
+   "en": "Exploud",
+   "de": "Krawumms",
+   "fr": "Brouhabam",
+   "ja": "Bakuong バクオング",
+   "ko": "P'ogŭmnyong 폭음룡",
+   "zh": "Bàoyīnguài 爆音怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/exploud.png",
+   "obs_code": "pokemon_3266739194"
+ },
+ {
+   "code": "Makuhita",
+   "en": "Makuhita",
+   "de": "Makuhita",
+   "fr": "Makuhita",
+   "ja": "Makunoshita マクノシタ",
+   "ko": "Mak'ŭt'ang 마크탕",
+   "zh": "Mùxiàlìshì 幕下力士",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/makuhita.png",
+   "obs_code": "pokemon_1819475395"
+ },
+ {
+   "code": "Hariyama",
+   "en": "Hariyama",
+   "de": "Hariyama",
+   "fr": "Hariyama",
+   "ja": "Hariteyama ハリテヤマ",
+   "ko": "Harimung 하리뭉",
+   "zh": "Chāolìwáng 超力王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hariyama.png",
+   "obs_code": "pokemon_2936269891"
+ },
+ {
+   "code": "Azurill",
+   "en": "Azurill",
+   "de": "Azurill",
+   "fr": "Azurill",
+   "ja": "Ruriri ルリリ",
+   "ko": "Ruriri 루리리",
+   "zh": "Lùlìlì 露力麗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/azurill.png",
+   "obs_code": "pokemon_4033110864"
+ },
+ {
+   "code": "Nosepass",
+   "en": "Nosepass",
+   "de": "Nasgnet",
+   "fr": "Tarinor",
+   "ja": "Nosepass ノズパス",
+   "ko": "K'ok'opasŭ 코코파스",
+   "zh": "Cháoběibí 朝北鼻",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nosepass.png",
+   "obs_code": "pokemon_1303154947"
+ },
+ {
+   "code": "Skitty",
+   "en": "Skitty",
+   "de": "Eneco",
+   "fr": "Skitty",
+   "ja": "Eneco エネコ",
+   "ko": "Enabi 에나비",
+   "zh": "Xiàngwěimiāo 向尾喵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skitty.png",
+   "obs_code": "pokemon_2224660365"
+ },
+ {
+   "code": "Delcatty",
+   "en": "Delcatty",
+   "de": "Enekoro",
+   "fr": "Delcatty",
+   "ja": "Enekororo エネコロロ",
+   "ko": "Telk'et'i 델케티",
+   "zh": "Yōuyǎmāo 優雅貓",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/delcatty.png",
+   "obs_code": "pokemon_302787059"
+ },
+ {
+   "code": "Sableye",
+   "en": "Sableye",
+   "de": "Zobiris",
+   "fr": "Tenefix",
+   "ja": "Yamirami ヤミラミ",
+   "ko": "Kkamkkami 깜까미",
+   "zh": "Gōuhúnyǎn 勾魂眼",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sableye.png",
+   "obs_code": "pokemon_265129472"
+ },
+ {
+   "code": "Mawile",
+   "en": "Mawile",
+   "de": "Flunkifer",
+   "fr": "Mysdibule",
+   "ja": "Kucheat クチート",
+   "ko": "Ipch'it'ŭ 입치트",
+   "zh": "Dàzuǐwá 大嘴娃",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mawile.png",
+   "obs_code": "pokemon_1165800574"
+ },
+ {
+   "code": "Aron",
+   "en": "Aron",
+   "de": "Stollunior",
+   "fr": "Galekid",
+   "ja": "Cokodora ココドラ",
+   "ko": "Kabori 가보리",
+   "zh": "Kěkěduōlā 可可多拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aron.png",
+   "obs_code": "pokemon_2087865879"
+ },
+ {
+   "code": "Lairon",
+   "en": "Lairon",
+   "de": "Stollrak",
+   "fr": "Galegon",
+   "ja": "Kodora コドラ",
+   "ko": "Kaengdora 갱도라",
+   "zh": "Kěduōlā 可多拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lairon.png",
+   "obs_code": "pokemon_1648248114"
+ },
+ {
+   "code": "Aggron",
+   "en": "Aggron",
+   "de": "Stolloss",
+   "fr": "Galeking",
+   "ja": "Bossgodora ボスゴドラ",
+   "ko": "Posŭrora 보스로라",
+   "zh": "Bōshìkěduōlā 波士可多拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aggron.png",
+   "obs_code": "pokemon_1648237431"
+ },
+ {
+   "code": "Meditite",
+   "en": "Meditite",
+   "de": "Meditie",
+   "fr": "Meditikka",
+   "ja": "Asanan アサナン",
+   "ko": "Yogarang 요가랑",
+   "zh": "Mǎshānà 瑪沙那",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meditite.png",
+   "obs_code": "pokemon_577139980"
+ },
+ {
+   "code": "Medicham",
+   "en": "Medicham",
+   "de": "Meditalis",
+   "fr": "Charmina",
+   "ja": "Charem チャーレム",
+   "ko": "Yogaraem 요가램",
+   "zh": "Qiàléimǔ 恰雷姆",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/medicham.png",
+   "obs_code": "pokemon_380989223"
+ },
+ {
+   "code": "Electrike",
+   "en": "Electrike",
+   "de": "Frizelbliz",
+   "fr": "Dynavolt",
+   "ja": "Rakurai ラクライ",
+   "ko": "Ssŏndŏrai 썬더라이",
+   "zh": "Luòléishòu 落雷獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/electrike.png",
+   "obs_code": "pokemon_1797615051"
+ },
+ {
+   "code": "Manectric",
+   "en": "Manectric",
+   "de": "Voltenso",
+   "fr": "Elecsprint",
+   "ja": "Livolt ライボルト",
+   "ko": "Ssŏndŏbolt'ŭ 썬더볼트",
+   "zh": "Léidiànshòu 雷電獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/manectric.png",
+   "obs_code": "pokemon_4158535597"
+ },
+ {
+   "code": "Plusle",
+   "en": "Plusle",
+   "de": "Plusle",
+   "fr": "Posipi",
+   "ja": "Prasle プラスル",
+   "ko": "P'ŭllŏsi 플러시",
+   "zh": "Zhèngdiànpāipāi 正電拍拍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/plusle.png",
+   "obs_code": "pokemon_1166841302"
+ },
+ {
+   "code": "Minun",
+   "en": "Minun",
+   "de": "Minun",
+   "fr": "Negapi",
+   "ja": "Minun マイナン",
+   "ko": "Mainong 마이농",
+   "zh": "Fùdiànpāipāi 負電拍拍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/minun.png",
+   "obs_code": "pokemon_181136468"
+ },
+ {
+   "code": "Volbeat",
+   "en": "Volbeat",
+   "de": "Volbeat",
+   "fr": "Muciole",
+   "ja": "Barubeat バルビート",
+   "ko": "Polbit'ŭ 볼비트",
+   "zh": "Diànyíngchóng 電螢蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/volbeat.png",
+   "obs_code": "pokemon_1675011458"
+ },
+ {
+   "code": "Illumise",
+   "en": "Illumise",
+   "de": "Illumise",
+   "fr": "Lumivole",
+   "ja": "Illumise イルミーゼ",
+   "ko": "Ne-obit'ŭ 네오비트",
+   "zh": "Tiántiányíng 甜甜螢",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/illumise.png",
+   "obs_code": "pokemon_1883741675"
+ },
+ {
+   "code": "Roselia",
+   "en": "Roselia",
+   "de": "Roselia",
+   "fr": "Roselia",
+   "ja": "Roselia ロゼリア",
+   "ko": "Rojellia 로젤리아",
+   "zh": "Dúqiángwéi 毒薔薇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/roselia.png",
+   "obs_code": "pokemon_490410538"
+ },
+ {
+   "code": "Gulpin",
+   "en": "Gulpin",
+   "de": "Schluppuck",
+   "fr": "Gloupti",
+   "ja": "Gokulin ゴクリン",
+   "ko": "Kkolkkakmon 꼴깍몬",
+   "zh": "Róngshíshòu 溶食獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gulpin.png",
+   "obs_code": "pokemon_1650552748"
+ },
+ {
+   "code": "Swalot",
+   "en": "Swalot",
+   "de": "Schlukwech",
+   "fr": "Avaltout",
+   "ja": "Marunoom マルノーム",
+   "ko": "Kkulkkŏkmon 꿀꺽몬",
+   "zh": "Tūnshíshòu 吞食獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swalot.png",
+   "obs_code": "pokemon_1753893879"
+ },
+ {
+   "code": "Carvanha",
+   "en": "Carvanha",
+   "de": "Kanivanha",
+   "fr": "Carvanha",
+   "ja": "Kibanha キバニア",
+   "ko": "Syap'ŭnia 샤프니아",
+   "zh": "Lìyáyú 利牙魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/carvanha.png",
+   "obs_code": "pokemon_442155333"
+ },
+ {
+   "code": "Sharpedo",
+   "en": "Sharpedo",
+   "de": "Tohaido",
+   "fr": "Sharpedo",
+   "ja": "Samehader サメハダー",
+   "ko": "Syak'ŭnia 샤크니아",
+   "zh": "Jùyáshā 巨牙鯊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sharpedo.png",
+   "obs_code": "pokemon_4194768915"
+ },
+ {
+   "code": "Wailmer",
+   "en": "Wailmer",
+   "de": "Wailmer",
+   "fr": "Wailmer",
+   "ja": "Hoeruko ホエルコ",
+   "ko": "Koraewangja 고래왕자",
+   "zh": "Hǒuhǒujīng 吼吼鯨",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wailmer.png",
+   "obs_code": "pokemon_1396231372"
+ },
+ {
+   "code": "Wailord",
+   "en": "Wailord",
+   "de": "Wailord",
+   "fr": "Wailord",
+   "ja": "Whaloh ホエルオー",
+   "ko": "Koraewang 고래왕",
+   "zh": "Hǒujīngwáng 吼鯨王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wailord.png",
+   "obs_code": "pokemon_3006410543"
+ },
+ {
+   "code": "Numel",
+   "en": "Numel",
+   "de": "Camaub",
+   "fr": "Chamallot",
+   "ja": "Donmel ドンメル",
+   "ko": "Tunt'a 둔타",
+   "zh": "Dāihuǒtuó 呆火駝",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/numel.png",
+   "obs_code": "pokemon_173599514"
+ },
+ {
+   "code": "Camerupt",
+   "en": "Camerupt",
+   "de": "Camerupt",
+   "fr": "Camerupt",
+   "ja": "Bakuuda バクーダ",
+   "ko": "P'okt'a 폭타",
+   "zh": "Pēnhuǒtuó 噴火駝",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/camerupt.png",
+   "obs_code": "pokemon_3708307052"
+ },
+ {
+   "code": "Torkoal",
+   "en": "Torkoal",
+   "de": "Qurtel",
+   "fr": "Chartor",
+   "ja": "Cotoise コータス",
+   "ko": "K'otŏsŭ 코터스",
+   "zh": "Méitàngūi 煤炭龜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/torkoal.png",
+   "obs_code": "pokemon_4216646885"
+ },
+ {
+   "code": "Spoink",
+   "en": "Spoink",
+   "de": "Spoink",
+   "fr": "Spoink",
+   "ja": "Baneboo バネブー",
+   "ko": "P'igŭjŏmp'ŭ 피그점프",
+   "zh": "Tiàotiàozhū 跳跳豬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spoink.png",
+   "obs_code": "pokemon_1830761669"
+ },
+ {
+   "code": "Grumpig",
+   "en": "Grumpig",
+   "de": "Groink",
+   "fr": "Groret",
+   "ja": "Boopig ブーピッグ",
+   "ko": "P'igŭk'ing 피그킹",
+   "zh": "Pūpūzhū 噗噗豬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/grumpig.png",
+   "obs_code": "pokemon_2954282134"
+ },
+ {
+   "code": "Spinda",
+   "en": "Spinda",
+   "de": "Pandir",
+   "fr": "Spinda",
+   "ja": "Patcheel パッチール",
+   "ko": "Ŏllugi 얼루기",
+   "zh": "Huànghuàngbān 晃晃斑",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spinda.png",
+   "obs_code": "pokemon_1304309860"
+ },
+ {
+   "code": "Trapinch",
+   "en": "Trapinch",
+   "de": "Knacklion",
+   "fr": "Kraknoix",
+   "ja": "Nuckrar ナックラー",
+   "ko": "T'opch'i 톱치",
+   "zh": "Dà'èyǐ 大顎蟻",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/trapinch.png",
+   "obs_code": "pokemon_1821196446"
+ },
+ {
+   "code": "Vibrava",
+   "en": "Vibrava",
+   "de": "Vibrava",
+   "fr": "Vibraninf",
+   "ja": "Vibrava ビブラーバ",
+   "ko": "Bibŭraba 비브라바",
+   "zh": "Chāoyīnbōyòuchóng 超音波幼蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vibrava.png",
+   "obs_code": "pokemon_622532732"
+ },
+ {
+   "code": "Flygon",
+   "en": "Flygon",
+   "de": "Libelldra",
+   "fr": "Libegon",
+   "ja": "Flygon フライゴン",
+   "ko": "P'ŭllaigon 플라이곤",
+   "zh": "Shāmòqīngtíng 沙漠蜻蜓",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/flygon.png",
+   "obs_code": "pokemon_1647793904"
+ },
+ {
+   "code": "Cacnea",
+   "en": "Cacnea",
+   "de": "Tuska",
+   "fr": "Cacnea",
+   "ja": "Sabonea サボネア",
+   "ko": "Sŏninwang 선인왕",
+   "zh": "Shāmònàiyà 沙漠奈亞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cacnea.png",
+   "obs_code": "pokemon_1303197518"
+ },
+ {
+   "code": "Cacturne",
+   "en": "Cacturne",
+   "de": "Noktuska",
+   "fr": "Cacturne",
+   "ja": "Noctus ノクタス",
+   "ko": "Bamsŏnin 밤선인",
+   "zh": "Mènggēnàiyà 夢歌奈亞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cacturne.png",
+   "obs_code": "pokemon_1131941980"
+ },
+ {
+   "code": "Swablu",
+   "en": "Swablu",
+   "de": "Wablu",
+   "fr": "Tylton",
+   "ja": "Tyltto チルット",
+   "ko": "P'abik'o 파비코",
+   "zh": "Qīngmiánniǎo 青綿鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swablu.png",
+   "obs_code": "pokemon_1792485467"
+ },
+ {
+   "code": "Altaria",
+   "en": "Altaria",
+   "de": "Altaria",
+   "fr": "Altaria",
+   "ja": "Tyltalis チルタリス",
+   "ko": "P'abik'ori 파비코리",
+   "zh": "Qīxìqīngniǎo 七夕青鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/altaria.png",
+   "obs_code": "pokemon_530403911"
+ },
+ {
+   "code": "Zangoose",
+   "en": "Zangoose",
+   "de": "Sengo",
+   "fr": "Mangriff",
+   "ja": "Zangoose ザングース",
+   "ko": "Chyanggo 쟝고",
+   "zh": "Māoyòuzhǎn 貓鼬斬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zangoose.png",
+   "obs_code": "pokemon_1799283521"
+ },
+ {
+   "code": "Seviper",
+   "en": "Seviper",
+   "de": "Vipitis",
+   "fr": "Seviper",
+   "ja": "Habunake ハブネーク",
+   "ko": "Sebip'ŏ 세비퍼",
+   "zh": "Fànchíshé 飯匙蛇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seviper.png",
+   "obs_code": "pokemon_1364832235"
+ },
+ {
+   "code": "Lunatone",
+   "en": "Lunatone",
+   "de": "Lunastein",
+   "fr": "Seleroc",
+   "ja": "Lunatone ルナトーン",
+   "ko": "Runat'on 루나톤",
+   "zh": "Yuèshí 月石",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lunatone.png",
+   "obs_code": "pokemon_37988803"
+ },
+ {
+   "code": "Solrock",
+   "en": "Solrock",
+   "de": "Sonnfel",
+   "fr": "Solaroc",
+   "ja": "Solrock ソルロック",
+   "ko": "Sollok 솔록",
+   "zh": "Tàiyángyán 太陽岩",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/solrock.png",
+   "obs_code": "pokemon_998798912"
+ },
+ {
+   "code": "Barboach",
+   "en": "Barboach",
+   "de": "Schmerbe",
+   "fr": "Barloche",
+   "ja": "Dojoach ドジョッチ",
+   "ko": "Mikkuri 미꾸리",
+   "zh": "Níníqiū 泥泥鰍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/barboach.png",
+   "obs_code": "pokemon_2455110291"
+ },
+ {
+   "code": "Whiscash",
+   "en": "Whiscash",
+   "de": "Welsar",
+   "fr": "Barbicha",
+   "ja": "Namazun ナマズン",
+   "ko": "Meging 메깅",
+   "zh": "Niányúwáng 鯰魚王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/whiscash.png",
+   "obs_code": "pokemon_1657356697"
+ },
+ {
+   "code": "Corphish",
+   "en": "Corphish",
+   "de": "Krebscorps",
+   "fr": "Ecrapince",
+   "ja": "Heigani ヘイガニ",
+   "ko": "Kajaegun 가재군",
+   "zh": "Lóngxiāxiǎobīng 龍蝦小兵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/corphish.png",
+   "obs_code": "pokemon_1359748689"
+ },
+ {
+   "code": "Crawdaunt",
+   "en": "Crawdaunt",
+   "de": "Krebutack",
+   "fr": "Colhomard",
+   "ja": "Shizariger シザリガー",
+   "ko": "Kajaejanggun 가재장군",
+   "zh": "Tiě'áolóngxiā 鐵螯龍蝦",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/crawdaunt.png",
+   "obs_code": "pokemon_3670117000"
+ },
+ {
+   "code": "Baltoy",
+   "en": "Baltoy",
+   "de": "Puppance",
+   "fr": "Balbuto",
+   "ja": "Yajilon ヤジロン",
+   "ko": "Ottukkun 오뚝군",
+   "zh": "Tiānpíng'ǒu 天秤偶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/baltoy.png",
+   "obs_code": "pokemon_2238871496"
+ },
+ {
+   "code": "Claydol",
+   "en": "Claydol",
+   "de": "Lepumentas",
+   "fr": "Kaorine",
+   "ja": "Nendoll ネンドール",
+   "ko": "Chŏmt'odori 점토도리",
+   "zh": "Niànlìtǔ'ōu 念力土偶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/claydol.png",
+   "obs_code": "pokemon_3981275029"
+ },
+ {
+   "code": "Lileep",
+   "en": "Lileep",
+   "de": "Liliep",
+   "fr": "Lilia",
+   "ja": "Lilyla リリーラ",
+   "ko": "Rilling 링링",
+   "zh": "Chùshǒubǎihé 觸手百合",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lileep.png",
+   "obs_code": "pokemon_1894518428"
+ },
+ {
+   "code": "Cradily",
+   "en": "Cradily",
+   "de": "Wielie",
+   "fr": "Vacilys",
+   "ja": "Yuradle ユレイドル",
+   "ko": "Rilliyo 릴리요",
+   "zh": "Yáolánbǎihé 搖籃百合",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cradily.png",
+   "obs_code": "pokemon_697542285"
+ },
+ {
+   "code": "Anorith",
+   "en": "Anorith",
+   "de": "Anorith",
+   "fr": "Anorith",
+   "ja": "Anopth アノプス",
+   "ko": "Anodipsŭ 아노딥스",
+   "zh": "Tàigǔyǔchóng 太古羽蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/anorith.png",
+   "obs_code": "pokemon_1215126082"
+ },
+ {
+   "code": "Armaldo",
+   "en": "Armaldo",
+   "de": "Armaldo",
+   "fr": "Armaldo",
+   "ja": "Armaldo アーマルド",
+   "ko": "Amaldo 아말도",
+   "zh": "Tàigǔkuījiǎ 太古盔甲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/armaldo.png",
+   "obs_code": "pokemon_248314749"
+ },
+ {
+   "code": "Feebas",
+   "en": "Feebas",
+   "de": "Barschwa",
+   "fr": "Barpau",
+   "ja": "Hinbass ヒンバス",
+   "ko": "Pint'ina 빈티나",
+   "zh": "Bènbènyú 笨笨魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/feebas.png",
+   "obs_code": "pokemon_2163463827"
+ },
+ {
+   "code": "Milotic",
+   "en": "Milotic",
+   "de": "Milotic",
+   "fr": "Milobellus",
+   "ja": "Milokaross ミロカロス",
+   "ko": "Millot'ik 밀로틱",
+   "zh": "Měinàsī 美納斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/milotic.png",
+   "obs_code": "pokemon_3820258428"
+ },
+ {
+   "code": "Castform",
+   "en": "Castform",
+   "de": "Formeo",
+   "fr": "Morpheo",
+   "ja": "Powalen ポワルン",
+   "ko": "K'aesŭp'ong 캐스퐁",
+   "zh": "Piāofúpàopào 漂浮泡泡",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/castform.png",
+   "obs_code": "pokemon_2845154486"
+ },
+ {
+   "code": "Kecleon",
+   "en": "Kecleon",
+   "de": "Kecleon",
+   "fr": "Kecleon",
+   "ja": "Kakureon カクレオン",
+   "ko": "K'ellimon 켈리몬",
+   "zh": "Biànyǐnlóng 變隱龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kecleon.png",
+   "obs_code": "pokemon_2830153600"
+ },
+ {
+   "code": "Shuppet",
+   "en": "Shuppet",
+   "de": "Shuppet",
+   "fr": "Polichombr",
+   "ja": "Kagebouzu カゲボウズ",
+   "ko": "Ŏdumnaesin 어둠대신",
+   "zh": "Yuànyǐngwáwá 怨影娃娃",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shuppet.png",
+   "obs_code": "pokemon_1800366970"
+ },
+ {
+   "code": "Banette",
+   "en": "Banette",
+   "de": "Banette",
+   "fr": "Branette",
+   "ja": "Juppeta ジュペッタ",
+   "ko": "Tak'ŭpet 다크펫",
+   "zh": "Zǔzhòuwáwá 詛咒娃娃",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/banette.png",
+   "obs_code": "pokemon_116397000"
+ },
+ {
+   "code": "Duskull",
+   "en": "Duskull",
+   "de": "Zwirrlicht",
+   "fr": "Skelenox",
+   "ja": "Yomawaru ヨマワル",
+   "ko": "Haegolmong 해골몽",
+   "zh": "Yèkūlú 夜骷顱",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/duskull.png",
+   "obs_code": "pokemon_4037812569"
+ },
+ {
+   "code": "Dusclops",
+   "en": "Dusclops",
+   "de": "Zwirrklop",
+   "fr": "Teraclope",
+   "ja": "Samayouru サマヨール",
+   "ko": "Miramong 미라몽",
+   "zh": "Yèjùrén 夜巨人",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dusclops.png",
+   "obs_code": "pokemon_220658436"
+ },
+ {
+   "code": "Tropius",
+   "en": "Tropius",
+   "de": "Tropius",
+   "fr": "Tropius",
+   "ja": "Tropius トロピウス",
+   "ko": "T'ŭrop'iusŭ 트로피우스",
+   "zh": "Rèdàilóng 熱帶龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tropius.png",
+   "obs_code": "pokemon_1901170931"
+ },
+ {
+   "code": "Chimecho",
+   "en": "Chimecho",
+   "de": "Palimpalim",
+   "fr": "Eoko",
+   "ja": "Chirean チリーン",
+   "ko": "Ch'irŏng 치렁",
+   "zh": "Fēnglínglíng 風鈴鈴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chimecho.png",
+   "obs_code": "pokemon_1496432363"
+ },
+ {
+   "code": "Absol",
+   "en": "Absol",
+   "de": "Absol",
+   "fr": "Absol",
+   "ja": "Absol アブソル",
+   "ko": "Aepsol 앱솔",
+   "zh": "Ābósuōlǔ 阿勃梭魯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/absol.png",
+   "obs_code": "pokemon_173268214"
+ },
+ {
+   "code": "Wynaut",
+   "en": "Wynaut",
+   "de": "Isso",
+   "fr": "Okeoke",
+   "ja": "Sohnano ソーナノ",
+   "ko": "Maja 마자",
+   "zh": "Xiǎoguǒrán 小果然",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wynaut.png",
+   "obs_code": "pokemon_1728344197"
+ },
+ {
+   "code": "Snorunt",
+   "en": "Snorunt",
+   "de": "Schneppke",
+   "fr": "Stalgamin",
+   "ja": "Yukiwarashi ユキワラシ",
+   "ko": "Nunkkoma 눈꼬마",
+   "zh": "Xuětóngzǐ 雪童子",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/snorunt.png",
+   "obs_code": "pokemon_1999405322"
+ },
+ {
+   "code": "Glalie",
+   "en": "Glalie",
+   "de": "Firnontor",
+   "fr": "Oniglali",
+   "ja": "Onigohri オニゴーリ",
+   "ko": "Ŏrŭmgwisin 얼음귀신",
+   "zh": "Bīngguǐhù 冰鬼護",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/glalie.png",
+   "obs_code": "pokemon_1160107183"
+ },
+ {
+   "code": "Spheal",
+   "en": "Spheal",
+   "de": "Seemops",
+   "fr": "Obalie",
+   "ja": "Tamazarashi タマザラシ",
+   "ko": "Taegulleo 대굴레오",
+   "zh": "Hǎibàoqiú 海豹球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spheal.png",
+   "obs_code": "pokemon_1429625318"
+ },
+ {
+   "code": "Sealeo",
+   "en": "Sealeo",
+   "de": "Seejong",
+   "fr": "Phogleur",
+   "ja": "Todoggler トドグラー",
+   "ko": "Ssireo 씨레오",
+   "zh": "Hǎimóshī 海魔獅",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sealeo.png",
+   "obs_code": "pokemon_1698367316"
+ },
+ {
+   "code": "Walrein",
+   "en": "Walrein",
+   "de": "Walraisa",
+   "fr": "Kaimorse",
+   "ja": "Todoseruga トドゼルガ",
+   "ko": "Ssik'aijŏ 씨카이저",
+   "zh": "Dìyǎhǎishī 帝牙海獅",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/walrein.png",
+   "obs_code": "pokemon_2913245519"
+ },
+ {
+   "code": "Clamperl",
+   "en": "Clamperl",
+   "de": "Perlu",
+   "fr": "Coquiperl",
+   "ja": "Pearlulu パールル",
+   "ko": "Chinjumong 진주몽",
+   "zh": "Zhēnzhūbèi 珍珠貝",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/clamperl.png",
+   "obs_code": "pokemon_1680216077"
+ },
+ {
+   "code": "Huntail",
+   "en": "Huntail",
+   "de": "Aalabyss",
+   "fr": "Serpang",
+   "ja": "Huntail ハンテール",
+   "ko": "Hŏnt'eil 헌테일",
+   "zh": "Lièbānyú 獵斑魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/huntail.png",
+   "obs_code": "pokemon_3911126790"
+ },
+ {
+   "code": "Gorebyss",
+   "en": "Gorebyss",
+   "de": "Saganabyss",
+   "fr": "Rosabyss",
+   "ja": "Sakurabyss サクラビス",
+   "ko": "Punhongjang'i 분홍장이",
+   "zh": "Yīnghuāyú 櫻花魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gorebyss.png",
+   "obs_code": "pokemon_2221200065"
+ },
+ {
+   "code": "Relicanth",
+   "en": "Relicanth",
+   "de": "Relicanth",
+   "fr": "Relicanth",
+   "ja": "Glanth ジーランス",
+   "ko": "Sirak'an 시라칸",
+   "zh": "Gǔkōngjíyú 古空棘魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/relicanth.png",
+   "obs_code": "pokemon_4102371303"
+ },
+ {
+   "code": "Luvdisc",
+   "en": "Luvdisc",
+   "de": "Liebiskus",
+   "fr": "Lovdisc",
+   "ja": "Lovecus ラブカス",
+   "ko": "Sarangdong'i 사랑동이",
+   "zh": "Àixīnyú 愛心魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/luvdisc.png",
+   "obs_code": "pokemon_4194339287"
+ },
+ {
+   "code": "Bagon",
+   "en": "Bagon",
+   "de": "Kindwurm",
+   "fr": "Draby",
+   "ja": "Tatsubay タツベイ",
+   "ko": "Agong'i 아공이",
+   "zh": "Bǎobèilóng 寶貝龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bagon.png",
+   "obs_code": "pokemon_180082880"
+ },
+ {
+   "code": "Shelgon",
+   "en": "Shelgon",
+   "de": "Draschel",
+   "fr": "Drackhaus",
+   "ja": "Komoruu コモルー",
+   "ko": "Swelgon 쉘곤",
+   "zh": "Jiákēlóng 甲殼龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shelgon.png",
+   "obs_code": "pokemon_2837118769"
+ },
+ {
+   "code": "Salamence",
+   "en": "Salamence",
+   "de": "Brutalanda",
+   "fr": "Drattak",
+   "ja": "Bohmander ボーマンダ",
+   "ko": "Pomanda 보만다",
+   "zh": "Bàoróngyuán 暴蠑螈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/salamence.png",
+   "obs_code": "pokemon_616236058"
+ },
+ {
+   "code": "Beldum",
+   "en": "Beldum",
+   "de": "Tanhel",
+   "fr": "Terhal",
+   "ja": "Dumbber ダンバル",
+   "ko": "Met'ang 메탕",
+   "zh": "Tiéyǎlíng 鐵啞鈴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/beldum.png",
+   "obs_code": "pokemon_1487415762"
+ },
+ {
+   "code": "Metang",
+   "en": "Metang",
+   "de": "Metang",
+   "fr": "Metang",
+   "ja": "Metang メタング",
+   "ko": "Met'anggu 메탕구",
+   "zh": "Jīnshǔguài 金屬怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/metang.png",
+   "obs_code": "pokemon_1389321201"
+ },
+ {
+   "code": "Metagross",
+   "en": "Metagross",
+   "de": "Metagross",
+   "fr": "Metalosse",
+   "ja": "Metagross メタグロス",
+   "ko": "Metagŭrosŭ 메타그로스",
+   "zh": "Jùjīnguài 巨金怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/metagross.png",
+   "obs_code": "pokemon_4004910498"
+ },
+ {
+   "code": "Regirock",
+   "en": "Regirock",
+   "de": "Regirock",
+   "fr": "Regirock",
+   "ja": "Regirock レジロック",
+   "ko": "Rejirak 레지락",
+   "zh": "Léijīluòkě 雷吉洛克",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/regirock.png",
+   "obs_code": "pokemon_2895426953"
+ },
+ {
+   "code": "Regice",
+   "en": "Regice",
+   "de": "Regice",
+   "fr": "Regice",
+   "ja": "Regice レジアイス",
+   "ko": "Rejiaisŭ 레지아이스",
+   "zh": "Léijī'àisī 雷吉艾斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/regice.png",
+   "obs_code": "pokemon_1158056570"
+ },
+ {
+   "code": "Registeel",
+   "en": "Registeel",
+   "de": "Registeel",
+   "fr": "Registeel",
+   "ja": "Registeel レジスチル",
+   "ko": "Rejisŭt'il 레지스틸",
+   "zh": "Léijīsīqílù 雷吉斯奇魯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/registeel.png",
+   "obs_code": "pokemon_2331537719"
+ },
+ {
+   "code": "Latias",
+   "en": "Latias",
+   "de": "Latias",
+   "fr": "Latias",
+   "ja": "Latias ラティアス",
+   "ko": "Ratiasŭ 라티아스",
+   "zh": "Lādìyāsī 拉帝亞斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/latias.png",
+   "obs_code": "pokemon_2163699175"
+ },
+ {
+   "code": "Latios",
+   "en": "Latios",
+   "de": "Latios",
+   "fr": "Latios",
+   "ja": "Latios ラティオス",
+   "ko": "Ratiosŭ 라티오스",
+   "zh": "Lādì'ōusī 拉帝歐斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/latios.png",
+   "obs_code": "pokemon_2170108905"
+ },
+ {
+   "code": "Kyogre",
+   "en": "Kyogre",
+   "de": "Kyogre",
+   "fr": "Kyogre",
+   "ja": "Kaiorga カイオーガ",
+   "ko": "Kaioga 가이오가",
+   "zh": "Gài'ōukǎ 蓋歐卡",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kyogre.png",
+   "obs_code": "pokemon_1168809512"
+ },
+ {
+   "code": "Groudon",
+   "en": "Groudon",
+   "de": "Groudon",
+   "fr": "Groudon",
+   "ja": "Groudon グラードン",
+   "ko": "Kŭrandon 그란돈",
+   "zh": "Gūlādūo 固拉多",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/groudon.png",
+   "obs_code": "pokemon_2831527503"
+ },
+ {
+   "code": "Rayquaza",
+   "en": "Rayquaza",
+   "de": "Rayquaza",
+   "fr": "Rayquaza",
+   "ja": "Rayquaza レックウザ",
+   "ko": "Rek'ujya 레쿠쟈",
+   "zh": "Lièkōngzuò 烈空坐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rayquaza.png",
+   "obs_code": "pokemon_1676170961"
+ },
+ {
+   "code": "Jirachi",
+   "en": "Jirachi",
+   "de": "Jirachi",
+   "fr": "Jirachi",
+   "ja": "Jirachi ジラーチ",
+   "ko": "Chirach'i 지라치",
+   "zh": "Jīlāqí 基拉祈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jirachi.png",
+   "obs_code": "pokemon_1662822359"
+ },
+ {
+   "code": "Deoxys (Normal Forme)",
+   "en": "Deoxys (Normal Forme)",
+   "de": "Deoxys",
+   "fr": "Deoxys",
+   "ja": "Deoxys デオキシス",
+   "ko": "Teokisŭ 데오키스",
+   "zh": "Dài'ōuqíxīsī 代歐奇希斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/deoxys-normal.png",
+   "obs_code": "pokemon_2883007079"
+ },
+ {
+   "code": "Turtwig",
+   "en": "Turtwig",
+   "de": "Chelast",
+   "fr": "Tortipouss",
+   "ja": "Naetle ナエトル",
+   "ko": "Mobugi 모부기",
+   "zh": "Cǎomiáoguī 草苗龜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/turtwig.png",
+   "obs_code": "pokemon_2952594587"
+ },
+ {
+   "code": "Grotle",
+   "en": "Grotle",
+   "de": "Chelcarain",
+   "fr": "Boskara",
+   "ja": "Hayashigame ハヤシガメ",
+   "ko": "Sup'ulbugi 수풀부기",
+   "zh": "Shùlínguī 樹林龜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/grotle.png",
+   "obs_code": "pokemon_1166541410"
+ },
+ {
+   "code": "Torterra",
+   "en": "Torterra",
+   "de": "Chelterrar",
+   "fr": "Torterra",
+   "ja": "Dodaitose ドダイトス",
+   "ko": "T'odaebugi 토대부기",
+   "zh": "Tǔtáiguī 土台龜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/torterra.png",
+   "obs_code": "pokemon_3739517660"
+ },
+ {
+   "code": "Chimchar",
+   "en": "Chimchar",
+   "de": "Panflam",
+   "fr": "Ouisticram",
+   "ja": "Hikozaru ヒコザル",
+   "ko": "Pulkkotsung'i 불꽃숭이",
+   "zh": "Xiǎohuǒyànhóu 小火焰猴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chimchar.png",
+   "obs_code": "pokemon_3882596210"
+ },
+ {
+   "code": "Monferno",
+   "en": "Monferno",
+   "de": "Panpyro",
+   "fr": "Chimpenfeu",
+   "ja": "Moukazaru モウカザル",
+   "ko": "P'aisung'i 파이숭이",
+   "zh": "Měnghuǒhóu 猛火猴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/monferno.png",
+   "obs_code": "pokemon_4177271257"
+ },
+ {
+   "code": "Infernape",
+   "en": "Infernape",
+   "de": "Panferno",
+   "fr": "Simiabraz",
+   "ja": "Goukazaru ゴウカザル",
+   "ko": "Ch'oyŏmmong 초염몽",
+   "zh": "Lièyànhóu 烈焰猴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/infernape.png",
+   "obs_code": "pokemon_2618909033"
+ },
+ {
+   "code": "Piplup",
+   "en": "Piplup",
+   "de": "Plinfa",
+   "fr": "Tiplouf",
+   "ja": "Pochama ポッチャマ",
+   "ko": "P'aengdori 팽도리",
+   "zh": "Bōjiāmàn 波加曼",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/piplup.png",
+   "obs_code": "pokemon_1875599461"
+ },
+ {
+   "code": "Prinplup",
+   "en": "Prinplup",
+   "de": "Pliprin",
+   "fr": "Prinplouf",
+   "ja": "Pottaishi ポッタイシ",
+   "ko": "P'aengt'aeja 팽태자",
+   "zh": "Bōwángzǐ 波皇子",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/prinplup.png",
+   "obs_code": "pokemon_2418197529"
+ },
+ {
+   "code": "Empoleon",
+   "en": "Empoleon",
+   "de": "Impoleon",
+   "fr": "Pingoléon",
+   "ja": "Emperte エンペルト",
+   "ko": "Emp'erŭt'ŭ 엠페르트",
+   "zh": "Dìwángnábō 帝王拿波",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/empoleon.png",
+   "obs_code": "pokemon_3200348026"
+ },
+ {
+   "code": "Starly",
+   "en": "Starly",
+   "de": "Staralili",
+   "fr": "Etourmi",
+   "ja": "Mukkuru ムックル",
+   "ko": "Tchirŭkko 찌르꼬",
+   "zh": "Mǔkè'ér 姆克兒",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/starly.png",
+   "obs_code": "pokemon_2233074532"
+ },
+ {
+   "code": "Staravia",
+   "en": "Staravia",
+   "de": "Staravia",
+   "fr": "Etourvol",
+   "ja": "Mukubird ムクバード",
+   "ko": "Tchirŭbŏdŭ 찌르버드",
+   "zh": "Mǔkèniǎo 姆克鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/staravia.png",
+   "obs_code": "pokemon_166854702"
+ },
+ {
+   "code": "Staraptor",
+   "en": "Staraptor",
+   "de": "Staraptor",
+   "fr": "Etouraptor",
+   "ja": "Mukuhawk ムクホーク",
+   "ko": "Tchirŭhok'ŭ 찌르호크",
+   "zh": "Mǔkèyīng 姆克鷹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/staraptor.png",
+   "obs_code": "pokemon_1502847977"
+ },
+ {
+   "code": "Bidoof",
+   "en": "Bidoof",
+   "de": "Bidiza",
+   "fr": "Keunotor",
+   "ja": "Bipper ビッパ",
+   "ko": "Pibŏni 비버니",
+   "zh": "Dàyálí 大牙狸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bidoof.png",
+   "obs_code": "pokemon_1353375372"
+ },
+ {
+   "code": "Bibarel",
+   "en": "Bibarel",
+   "de": "Bidifas",
+   "fr": "Castorno",
+   "ja": "Beadull ビーダル",
+   "ko": "Pibŏtong 비버통",
+   "zh": "Dàwěilí 大尾狸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bibarel.png",
+   "obs_code": "pokemon_102881910"
+ },
+ {
+   "code": "Kricketot",
+   "en": "Kricketot",
+   "de": "Zirpurze",
+   "fr": "Crikzik",
+   "ja": "Koroboshi コロボーシ",
+   "ko": "Kwittulttugi 귀뚤뚜기",
+   "zh": "Yuánfǎshī 圓法師",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kricketot.png",
+   "obs_code": "pokemon_3753099383"
+ },
+ {
+   "code": "Kricketune",
+   "en": "Kricketune",
+   "de": "Zirpeise",
+   "fr": "Mélokrik",
+   "ja": "Korotok コロトック",
+   "ko": "Kwittult'okk'ŭ 귀뚤톡크",
+   "zh": "Yīnxiāngshuài 音箱蟀",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kricketune.png",
+   "obs_code": "pokemon_1888494802"
+ },
+ {
+   "code": "Shinx",
+   "en": "Shinx",
+   "de": "Sheinux",
+   "fr": "Lixy",
+   "ja": "Kolink コリンク",
+   "ko": "Kkoringk'ŭ 꼬링크",
+   "zh": "Xiǎomāoguài 小貓怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shinx.png",
+   "obs_code": "pokemon_196656129"
+ },
+ {
+   "code": "Luxio",
+   "en": "Luxio",
+   "de": "Luxio",
+   "fr": "Luxio",
+   "ja": "Luxio ルクシオ",
+   "ko": "Rŏksio 럭시오",
+   "zh": "Lèkèmāo 勒克貓",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/luxio.png",
+   "obs_code": "pokemon_181223746"
+ },
+ {
+   "code": "Luxray",
+   "en": "Luxray",
+   "de": "Luxtra",
+   "fr": "Luxray",
+   "ja": "Rentorer レントラー",
+   "ko": "Rent'ŭra 렌트라",
+   "zh": "Lúnqínmāo 倫琴貓",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/luxray.png",
+   "obs_code": "pokemon_2246197646"
+ },
+ {
+   "code": "Budew",
+   "en": "Budew",
+   "de": "Knospi",
+   "fr": "Rozbouton",
+   "ja": "Subomie スボミー",
+   "ko": "Kkomong'ul 꼬몽울",
+   "zh": "Hánxiūbāo 含羞苞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/budew.png",
+   "obs_code": "pokemon_191111876"
+ },
+ {
+   "code": "Roserade",
+   "en": "Roserade",
+   "de": "Roserade",
+   "fr": "Roserade",
+   "ja": "Roserade ロズレイド",
+   "ko": "Rojŭreidŭ 로즈레이드",
+   "zh": "Luósīléiduǒ 羅絲雷朵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/roserade.png",
+   "obs_code": "pokemon_1115990172"
+ },
+ {
+   "code": "Cranidos",
+   "en": "Cranidos",
+   "de": "Koknodon",
+   "fr": "Kranidos",
+   "ja": "Zugaidos ズガイドス",
+   "ko": "Tugaedosŭ 두개도스",
+   "zh": "Tóugàilóng 頭蓋龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cranidos.png",
+   "obs_code": "pokemon_1749739242"
+ },
+ {
+   "code": "Rampardos",
+   "en": "Rampardos",
+   "de": "Rameidon",
+   "fr": "Charkos",
+   "ja": "Rampard ラムパルド",
+   "ko": "Raemp'ŏldŭ 램펄드",
+   "zh": "Zhànchuílóng 戰槌龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rampardos.png",
+   "obs_code": "pokemon_1776847936"
+ },
+ {
+   "code": "Shieldon",
+   "en": "Shieldon",
+   "de": "Schilterus",
+   "fr": "Dinoclier",
+   "ja": "Tatetops タテトプス",
+   "ko": "Pangp'aet'opsŭ 방패톱스",
+   "zh": "Dùnjiǎlóng 盾甲龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shieldon.png",
+   "obs_code": "pokemon_3237443387"
+ },
+ {
+   "code": "Bastiodon",
+   "en": "Bastiodon",
+   "de": "Bollterus",
+   "fr": "Bastiodon",
+   "ja": "Trideps トリデプス",
+   "ko": "Parit'opsŭ 바리톱스",
+   "zh": "Hùchénglóng 護城龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bastiodon.png",
+   "obs_code": "pokemon_3947930978"
+ },
+ {
+   "code": "Burmy",
+   "en": "Burmy",
+   "de": "Burmy",
+   "fr": "Cheniti",
+   "ja": "Minomutchi ミノムッチ",
+   "ko": "Torongch'ung'i 도롱충이",
+   "zh": "Jiécǎo'ér 結草兒",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/burmy.png",
+   "obs_code": "pokemon_197786324"
+ },
+ {
+   "code": "Wormadam (Plant Cloak)",
+   "en": "Wormadam (Plant Cloak)",
+   "de": "Burmadame",
+   "fr": "Cheniselle",
+   "ja": "Minomadam ミノマダム",
+   "ko": "Torongmadam 도롱마담",
+   "zh": "Jiécǎoguìfù 結草貴婦",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wormadam-plant.png",
+   "obs_code": "pokemon_371712961"
+ },
+ {
+   "code": "Mothim",
+   "en": "Mothim",
+   "de": "Moterpel",
+   "fr": "Papilord",
+   "ja": "Garmeil ガーメイル",
+   "ko": "Nameil 나메일",
+   "zh": "Shēnshì'é 紳士蛾",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mothim.png",
+   "obs_code": "pokemon_1454667039"
+ },
+ {
+   "code": "Combee",
+   "en": "Combee",
+   "de": "Wadribie",
+   "fr": "Apitrini",
+   "ja": "Mitsuhoney ミツハニー",
+   "ko": "Sekkulbŏri 세꿀버리",
+   "zh": "Sānmìfēng 三蜜蜂",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/combee.png",
+   "obs_code": "pokemon_1155722502"
+ },
+ {
+   "code": "Vespiquen",
+   "en": "Vespiquen",
+   "de": "Honweisel",
+   "fr": "Apireine",
+   "ja": "Beequeen ビークイン",
+   "ko": "Pikwin 비퀸",
+   "zh": "Fēnghòu 蜂后",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vespiquen.png",
+   "obs_code": "pokemon_3596545267"
+ },
+ {
+   "code": "Pachirisu",
+   "en": "Pachirisu",
+   "de": "Pachirisu",
+   "fr": "Pachirisu",
+   "ja": "Pachirisu パチリス",
+   "ko": "P'ach'irisŭ 파치리스",
+   "zh": "Pàqílìzī 帕奇利茲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pachirisu.png",
+   "obs_code": "pokemon_1553818507"
+ },
+ {
+   "code": "Buizel",
+   "en": "Buizel",
+   "de": "Bamelin",
+   "fr": "Mustébouée",
+   "ja": "Buoysel ブイゼル",
+   "ko": "Pŭijel 브이젤",
+   "zh": "Yǒngqìyòu 泳氣鼬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/buizel.png",
+   "obs_code": "pokemon_1434494184"
+ },
+ {
+   "code": "Floatzel",
+   "en": "Floatzel",
+   "de": "Bojelin",
+   "fr": "Mustéflott",
+   "ja": "Flowsel フローゼル",
+   "ko": "P'ŭllojel 플로젤",
+   "zh": "Fúqiǎnyòu 浮潛鼬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/floatzel.png",
+   "obs_code": "pokemon_3059610022"
+ },
+ {
+   "code": "Cherubi",
+   "en": "Cherubi",
+   "de": "Kikugi",
+   "fr": "Ceribou",
+   "ja": "Cherinbo チェリンボ",
+   "ko": "Ch'eribŏ 체리버",
+   "zh": "Yīnghuābǎo 櫻花寶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cherubi.png",
+   "obs_code": "pokemon_1908946631"
+ },
+ {
+   "code": "Cherrim",
+   "en": "Cherrim",
+   "de": "Kinoso",
+   "fr": "Ceriflor",
+   "ja": "Cherrim チェリム",
+   "ko": "Ch'erikko 체리꼬",
+   "zh": "Yīnghuā'ér 櫻花兒",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cherrim.png",
+   "obs_code": "pokemon_774620143"
+ },
+ {
+   "code": "Shellos",
+   "en": "Shellos",
+   "de": "Schalellos",
+   "fr": "Sancoki",
+   "ja": "Karanakushi カラナクシ",
+   "ko": "Kkapjilmu 깝질무",
+   "zh": "Wúkéhǎiniú 無殼海牛",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shellos.png",
+   "obs_code": "pokemon_2907517159"
+ },
+ {
+   "code": "Gastrodon",
+   "en": "Gastrodon",
+   "de": "Gastrodon",
+   "fr": "Tritosor",
+   "ja": "Toritodon トリトドン",
+   "ko": "T'ŭrit'odon 트리토돈",
+   "zh": "Hǎiniúshòu 海牛獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gastrodon.png",
+   "obs_code": "pokemon_3967200572"
+ },
+ {
+   "code": "Ambipom",
+   "en": "Ambipom",
+   "de": "Ambidiffel",
+   "fr": "Capidextre",
+   "ja": "Eteboth エテボース",
+   "ko": "Kethaenbosung 겟핸보숭",
+   "zh": "Shuāngwěiguàishǒu 雙尾怪手",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ambipom.png",
+   "obs_code": "pokemon_1154948208"
+ },
+ {
+   "code": "Drifloon",
+   "en": "Drifloon",
+   "de": "Driftlon",
+   "fr": "Baudrive",
+   "ja": "Fuwante フワンテ",
+   "ko": "Hŭndŭlp'ungson 흔들풍손",
+   "zh": "Piāopiāoqiú 飄飄球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drifloon.png",
+   "obs_code": "pokemon_3724766974"
+ },
+ {
+   "code": "Drifblim",
+   "en": "Drifblim",
+   "de": "Drifzepeli",
+   "fr": "Grodrive",
+   "ja": "Fuwaride フワライド",
+   "ko": "Tungsillaidŭ 둥실라이드",
+   "zh": "Fùhèqìqiú 附和氣球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drifblim.png",
+   "obs_code": "pokemon_3724597686"
+ },
+ {
+   "code": "Buneary",
+   "en": "Buneary",
+   "de": "Haspiror",
+   "fr": "Laporeille",
+   "ja": "Mimirol ミミロル",
+   "ko": "Iŏrol 이어롤",
+   "zh": "Juǎnjuǎn'ěr 捲捲耳",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/buneary.png",
+   "obs_code": "pokemon_457590675"
+ },
+ {
+   "code": "Lopunny",
+   "en": "Lopunny",
+   "de": "Schlapor",
+   "fr": "Lockpin",
+   "ja": "Mimilop ミミロップ",
+   "ko": "Iŏrop 이어롭",
+   "zh": "Cháng'ěrtù 長耳兔",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lopunny.png",
+   "obs_code": "pokemon_631367386"
+ },
+ {
+   "code": "Mismagius",
+   "en": "Mismagius",
+   "de": "Traunmagil",
+   "fr": "Magirêve",
+   "ja": "Mumage ムウマージ",
+   "ko": "Muumajik 무우마직",
+   "zh": "Mèngyāomó 夢妖魔",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mismagius.png",
+   "obs_code": "pokemon_4067727894"
+ },
+ {
+   "code": "Honchkrow",
+   "en": "Honchkrow",
+   "de": "Kramshef",
+   "fr": "Corboss",
+   "ja": "Donkarasu ドンカラス",
+   "ko": "Tonk'ŭrou 돈크로우",
+   "zh": "Wūyātóutóu 烏鴉頭頭",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/honchkrow.png",
+   "obs_code": "pokemon_1914657990"
+ },
+ {
+   "code": "Glameow",
+   "en": "Glameow",
+   "de": "Charmian",
+   "fr": "Chaglam",
+   "ja": "Nyarmar ニャルマー",
+   "ko": "Naongma 나옹마",
+   "zh": "Mèilìmiāo 魅力喵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/glameow.png",
+   "obs_code": "pokemon_2341286751"
+ },
+ {
+   "code": "Purugly",
+   "en": "Purugly",
+   "de": "Shnurgarst",
+   "fr": "Chaffreux",
+   "ja": "Bunyat ブニャット",
+   "ko": "Monnyang'i 몬냥이",
+   "zh": "Dōngshīmiāo 東施喵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/purugly.png",
+   "obs_code": "pokemon_698956117"
+ },
+ {
+   "code": "Chingling",
+   "en": "Chingling",
+   "de": "Klingplim",
+   "fr": "Korillon",
+   "ja": "Lisyan リーシャン",
+   "ko": "Rangttallang 랑딸랑",
+   "zh": "Língdāngxiǎng 鈴噹響",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chingling.png",
+   "obs_code": "pokemon_1278964674"
+ },
+ {
+   "code": "Stunky",
+   "en": "Stunky",
+   "de": "Skunkapuh",
+   "fr": "Moufouette",
+   "ja": "Skunpoo スカンプー",
+   "ko": "Sŭk'ŏngppung 스컹뿡",
+   "zh": "Chòuyòupū 臭鼬噗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stunky.png",
+   "obs_code": "pokemon_2244233323"
+ },
+ {
+   "code": "Skuntank",
+   "en": "Skuntank",
+   "de": "Skuntank",
+   "fr": "Moufflair",
+   "ja": "Skutank スカタンク",
+   "ko": "Sŭk'ŏngt'aengk'ŭ 스컹탱크",
+   "zh": "Tǎnkèchòuyòu 坦克臭鼬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skuntank.png",
+   "obs_code": "pokemon_541429558"
+ },
+ {
+   "code": "Bronzor",
+   "en": "Bronzor",
+   "de": "Bronzel",
+   "fr": "Archéomire",
+   "ja": "Domirror ドーミラー",
+   "ko": "Tongmirŏ 동미러",
+   "zh": "Tóngjìngguài 銅鏡怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bronzor.png",
+   "obs_code": "pokemon_1436210099"
+ },
+ {
+   "code": "Bronzong",
+   "en": "Bronzong",
+   "de": "Bronzong",
+   "fr": "Archéodong",
+   "ja": "Dotakun ドータクン",
+   "ko": "Tongtakkun 동탁군",
+   "zh": "Qīngtóngzhōng 青銅鐘",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bronzong.png",
+   "obs_code": "pokemon_615369096"
+ },
+ {
+   "code": "Bonsly",
+   "en": "Bonsly",
+   "de": "Mobai",
+   "fr": "Manzaï",
+   "ja": "Usohachi ウソハチ",
+   "ko": "Kkojiji 꼬지지",
+   "zh": "Àikūshù 愛哭樹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bonsly.png",
+   "obs_code": "pokemon_2233047328"
+ },
+ {
+   "code": "Mime Jr.",
+   "en": "Mime Jr.",
+   "de": "Pantimimi",
+   "fr": "Mime Jr.",
+   "ja": "Manene マネネ",
+   "ko": "Hyungnaenae 흉내내",
+   "zh": "Móníní 魔尼尼",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mime-jr.png",
+   "obs_code": "pokemon_1644555676"
+ },
+ {
+   "code": "Happiny",
+   "en": "Happiny",
+   "de": "Wonneira",
+   "fr": "Ptiravi",
+   "ja": "Pinpuku ピンプク",
+   "ko": "P'ingbok 핑복",
+   "zh": "Hǎoyùndàn 好運蛋",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/happiny.png",
+   "obs_code": "pokemon_623173938"
+ },
+ {
+   "code": "Chatot",
+   "en": "Chatot",
+   "de": "Plaudagei",
+   "fr": "Pijako",
+   "ja": "Perap ペラップ",
+   "ko": "P'erap'e 페라페",
+   "zh": "Guāzàoniǎo 聒噪鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chatot.png",
+   "obs_code": "pokemon_1753606400"
+ },
+ {
+   "code": "Spiritomb",
+   "en": "Spiritomb",
+   "de": "Kryppuk",
+   "fr": "Spiritomb",
+   "ja": "Mikaruge ミカルゲ",
+   "ko": "Hwagangdol 화강돌",
+   "zh": "Huāyánguài 花岩怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spiritomb.png",
+   "obs_code": "pokemon_395269792"
+ },
+ {
+   "code": "Gible",
+   "en": "Gible",
+   "de": "Kaumalat",
+   "fr": "Griknot",
+   "ja": "Fukamaru フカマル",
+   "ko": "Tipsang'ŏdong 딥상어동",
+   "zh": "Yuánlùshā 圓陸鯊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gible.png",
+   "obs_code": "pokemon_165493280"
+ },
+ {
+   "code": "Gabite",
+   "en": "Gabite",
+   "de": "Knarksel",
+   "fr": "Carmache",
+   "ja": "Gabite ガバイト",
+   "ko": "Hanbait'ŭ 한바이트",
+   "zh": "Jiānyálùshā 尖牙陸鯊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gabite.png",
+   "obs_code": "pokemon_1175848633"
+ },
+ {
+   "code": "Garchomp",
+   "en": "Garchomp",
+   "de": "Knakrack",
+   "fr": "Carchacrok",
+   "ja": "Gablias ガブリアス",
+   "ko": "Hankariasŭ 한카리아스",
+   "zh": "Lièyǎolùshā 烈咬陸鯊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/garchomp.png",
+   "obs_code": "pokemon_2906394984"
+ },
+ {
+   "code": "Munchlax",
+   "en": "Munchlax",
+   "de": "Mampfaxo",
+   "fr": "Goinfrex",
+   "ja": "Gonbe ゴンベ",
+   "ko": "Mŏkgoja 먹고자",
+   "zh": "Xiǎokǎbǐshòu 小卡比獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/munchlax.png",
+   "obs_code": "pokemon_3174522829"
+ },
+ {
+   "code": "Riolu",
+   "en": "Riolu",
+   "de": "Riolu",
+   "fr": "Riolu",
+   "ja": "Riolu リオル",
+   "ko": "Riorŭ 리오르",
+   "zh": "Lì'ōulù 利歐路",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/riolu.png",
+   "obs_code": "pokemon_184454504"
+ },
+ {
+   "code": "Lucario",
+   "en": "Lucario",
+   "de": "Lucario",
+   "fr": "Lucario",
+   "ja": "Lucario ルカリオ",
+   "ko": "Ruk'ario 루카리오",
+   "zh": "Lùkǎlì'ōu 路卡利歐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lucario.png",
+   "obs_code": "pokemon_4063120234"
+ },
+ {
+   "code": "Hippopotas",
+   "en": "Hippopotas",
+   "de": "Hippopotas",
+   "fr": "Hippopotas",
+   "ja": "Hippopotas ヒポポタス",
+   "ko": "Hip'op'ot'asŭ 히포포타스",
+   "zh": "Guàihémǎ 怪河馬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hippopotas.png",
+   "obs_code": "pokemon_4287581586"
+ },
+ {
+   "code": "Hippowdon",
+   "en": "Hippowdon",
+   "de": "Hippoterus",
+   "fr": "Hippodocus",
+   "ja": "Kabarudon カバルドン",
+   "ko": "Hamadon 하마돈",
+   "zh": "河馬獸 河馬獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hippowdon.png",
+   "obs_code": "pokemon_4267304889"
+ },
+ {
+   "code": "Skorupi",
+   "en": "Skorupi",
+   "de": "Pionskora",
+   "fr": "Drapion",
+   "ja": "Scorpi スコルピ",
+   "ko": "Sŭk'olp'i 스콜피",
+   "zh": "Zǐtiānxiē 紫天蠍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skorupi.png",
+   "obs_code": "pokemon_2571838764"
+ },
+ {
+   "code": "Drapion",
+   "en": "Drapion",
+   "de": "Piondragi",
+   "fr": "Drascore",
+   "ja": "Dorapion ドラピオン",
+   "ko": "Tŭraep'ion 드래피온",
+   "zh": "Lóngwángxiē 龍王蠍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drapion.png",
+   "obs_code": "pokemon_2844530282"
+ },
+ {
+   "code": "Croagunk",
+   "en": "Croagunk",
+   "de": "Glibunkel",
+   "fr": "Cradopaud",
+   "ja": "Gureggru グレッグル",
+   "ko": "Ppittakkuri 삐딱구리",
+   "zh": "Bùliángwā 不良蛙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/croagunk.png",
+   "obs_code": "pokemon_1303677165"
+ },
+ {
+   "code": "Toxicroak",
+   "en": "Toxicroak",
+   "de": "Toxiquak",
+   "fr": "Coatox",
+   "ja": "Dokurog ドクロッグ",
+   "ko": "Tokkaegul 독개굴",
+   "zh": "Dúkūwā 毒骷蛙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/toxicroak.png",
+   "obs_code": "pokemon_2023405499"
+ },
+ {
+   "code": "Carnivine",
+   "en": "Carnivine",
+   "de": "Venuflibis",
+   "fr": "Vortente",
+   "ja": "Muskippa マスキッパ",
+   "ko": "Musŭt'ŭmni 무스틈니",
+   "zh": "Jiānyálóng 尖牙籠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/carnivine.png",
+   "obs_code": "pokemon_3758007526"
+ },
+ {
+   "code": "Finneon",
+   "en": "Finneon",
+   "de": "Finneon",
+   "fr": "Ecayon",
+   "ja": "Keikouo ケイコウオ",
+   "ko": "Hyŏnggwang'ŏ 형광어",
+   "zh": "Yíngguāngyú 螢光魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/finneon.png",
+   "obs_code": "pokemon_2830355214"
+ },
+ {
+   "code": "Lumineon",
+   "en": "Lumineon",
+   "de": "Lumineon",
+   "fr": "Luminéon",
+   "ja": "Neorant ネオラント",
+   "ko": "Neorait'ŭ 네오라이트",
+   "zh": "Níhóngyú 霓虹魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lumineon.png",
+   "obs_code": "pokemon_3207521394"
+ },
+ {
+   "code": "Mantyke",
+   "en": "Mantyke",
+   "de": "Mantirps",
+   "fr": "Babimanta",
+   "ja": "Tamanta タマンタ",
+   "ko": "T'amant'a 타만타",
+   "zh": "Xiǎoqiúfēiyú 小球飛魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mantyke.png",
+   "obs_code": "pokemon_4168882372"
+ },
+ {
+   "code": "Snover",
+   "en": "Snover",
+   "de": "Shnebedeck",
+   "fr": "Blizzi",
+   "ja": "Yukikabli ユキカブリ",
+   "ko": "Nunssŭgae 눈쓰개",
+   "zh": "Xuělìguài 雪笠怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/snover.png",
+   "obs_code": "pokemon_2123692374"
+ },
+ {
+   "code": "Abomasnow",
+   "en": "Abomasnow",
+   "de": "Rexblisar",
+   "fr": "Blizzaroi",
+   "ja": "Yukinooh ユキノオー",
+   "ko": "Nunsŏlwang 눈설왕",
+   "zh": "Bàoxuěwáng 暴雪王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/abomasnow.png",
+   "obs_code": "pokemon_2462166176"
+ },
+ {
+   "code": "Weavile",
+   "en": "Weavile",
+   "de": "Snibunna",
+   "fr": "Dimoret",
+   "ja": "Manyula マニューラ",
+   "ko": "P'op'unira 포푸니아",
+   "zh": "Mǎniǔlā 瑪狃拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/weavile.png",
+   "obs_code": "pokemon_4111640288"
+ },
+ {
+   "code": "Magnezone",
+   "en": "Magnezone",
+   "de": "Magnezone",
+   "fr": "Magnézone",
+   "ja": "Jibacoil ジバコイル",
+   "ko": "Chap'ok'oil 자포코일",
+   "zh": "Zìbàocíguài 自爆磁怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magnezone.png",
+   "obs_code": "pokemon_1644142011"
+ },
+ {
+   "code": "Lickilicky",
+   "en": "Lickilicky",
+   "de": "Schlurplek",
+   "fr": "Coudlangue",
+   "ja": "Berobelt ベロベルト",
+   "ko": "Naerumbelt'ŭ 내룸벨트",
+   "zh": "Dàshétiǎn 大舌舔",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lickilicky.png",
+   "obs_code": "pokemon_291792533"
+ },
+ {
+   "code": "Rhyperior",
+   "en": "Rhyperior",
+   "de": "Rihornior",
+   "fr": "Rhinastoc",
+   "ja": "Dosidon ドサイドン",
+   "ko": "Kŏdaek'oppuri 거대코뿌리",
+   "zh": "Chāotiěbàolóng 超鐵暴龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rhyperior.png",
+   "obs_code": "pokemon_144032117"
+ },
+ {
+   "code": "Tangrowth",
+   "en": "Tangrowth",
+   "de": "Tangoloss",
+   "fr": "Bouldeneu",
+   "ja": "Mojanbo モジャンボ",
+   "ko": "Tŏngk'urimbo 덩쿠림보",
+   "zh": "Jùmànténg 巨蔓藤",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tangrowth.png",
+   "obs_code": "pokemon_3122010287"
+ },
+ {
+   "code": "Electivire",
+   "en": "Electivire",
+   "de": "Elevoltek",
+   "fr": "Elekable",
+   "ja": "Elekible エレキブル",
+   "ko": "Erek'ibŭl 에레키블",
+   "zh": "Diànjímóshòu 電擊魔獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/electivire.png",
+   "obs_code": "pokemon_443030495"
+ },
+ {
+   "code": "Magmortar",
+   "en": "Magmortar",
+   "de": "Magbrant",
+   "fr": "Maganon",
+   "ja": "Booburn ブーバーン",
+   "ko": "Mageumabŏn 마그마번",
+   "zh": "Yāzuǐyànlóng 鴨嘴焰龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magmortar.png",
+   "obs_code": "pokemon_2465539577"
+ },
+ {
+   "code": "Togekiss",
+   "en": "Togekiss",
+   "de": "Togekiss",
+   "fr": "Togekiss",
+   "ja": "Togekiss トゲキッス",
+   "ko": "T'ogek'isŭ 토게키스",
+   "zh": "Bōkèjīsī 波克基斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/togekiss.png",
+   "obs_code": "pokemon_1584239902"
+ },
+ {
+   "code": "Yanmega",
+   "en": "Yanmega",
+   "de": "Yanmega",
+   "fr": "Yanmega",
+   "ja": "Megayanma メガヤンマ",
+   "ko": "Megajari 메가자리",
+   "zh": "Méikǎyángmǎ 梅卡陽瑪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/yanmega.png",
+   "obs_code": "pokemon_270983805"
+ },
+ {
+   "code": "Leafeon",
+   "en": "Leafeon",
+   "de": "Folipurba",
+   "fr": "Phyllali",
+   "ja": "Leafia リーフィア",
+   "ko": "Rip'ia 리피아",
+   "zh": "Yèjīnglíng 葉精靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/leafeon.png",
+   "obs_code": "pokemon_2830079567"
+ },
+ {
+   "code": "Glaceon",
+   "en": "Glaceon",
+   "de": "Glaziola",
+   "fr": "Givrali",
+   "ja": "Glacia グレイシア",
+   "ko": "Kŭlleisia 글레이시아",
+   "zh": "Bīngjīnglíng 冰精靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/glaceon.png",
+   "obs_code": "pokemon_2829689096"
+ },
+ {
+   "code": "Gliscor",
+   "en": "Gliscor",
+   "de": "Skorgro",
+   "fr": "Scorvol",
+   "ja": "Glion グライオン",
+   "ko": "Kŭllaion 글라이온",
+   "zh": "Tiānxiēwáng 天蠍王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gliscor.png",
+   "obs_code": "pokemon_1471510922"
+ },
+ {
+   "code": "Mamoswine",
+   "en": "Mamoswine",
+   "de": "Mamutel",
+   "fr": "Mammochon",
+   "ja": "Manmoo マンムー",
+   "ko": "Mammokkuri 맘모꾸리",
+   "zh": "Xiàngyázhū 象牙豬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mamoswine.png",
+   "obs_code": "pokemon_3771588589"
+ },
+ {
+   "code": "Porygon-Z",
+   "en": "Porygon-Z",
+   "de": "Porygon-Z",
+   "fr": "Porygon-Z",
+   "ja": "PorygonZ ポリゴンZ",
+   "ko": "P'olligon Z 폴리곤Ｚ",
+   "zh": "3D-Lóng Z 3D龍Z",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/porygon-z.png",
+   "obs_code": "pokemon_1763752832"
+ },
+ {
+   "code": "Gallade",
+   "en": "Gallade",
+   "de": "Galagladi",
+   "fr": "Gallame",
+   "ja": "Erlade エルレイド",
+   "ko": "Elleidŭ 엘레이드",
+   "zh": "Àilùléiduǒ 艾路雷朵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gallade.png",
+   "obs_code": "pokemon_3807818979"
+ },
+ {
+   "code": "Probopass",
+   "en": "Probopass",
+   "de": "Voluminas",
+   "fr": "Tarinorme",
+   "ja": "Dainose ダイノーズ",
+   "ko": "Taek'op'asŭ 대코파스",
+   "zh": "Dàcháoběibí 大朝北鼻",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/probopass.png",
+   "obs_code": "pokemon_62081652"
+ },
+ {
+   "code": "Dusknoir",
+   "en": "Dusknoir",
+   "de": "Zwirrfinst",
+   "fr": "Noctunoir",
+   "ja": "Yonoir ヨノワール",
+   "ko": "Yanŭwarŭmong 야느와르몽",
+   "zh": "Yèhēimórén 夜黑魔人",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dusknoir.png",
+   "obs_code": "pokemon_603559286"
+ },
+ {
+   "code": "Froslass",
+   "en": "Froslass",
+   "de": "Frosdedje",
+   "fr": "Momartik",
+   "ja": "Yukimenoko ユキメノコ",
+   "ko": "Nun'yŏa 눈여아",
+   "zh": "Xuěyāonǚ 雪妖女",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/froslass.png",
+   "obs_code": "pokemon_1289583200"
+ },
+ {
+   "code": "Rotom",
+   "en": "Rotom",
+   "de": "Rotom",
+   "fr": "Motisma",
+   "ja": "Rotom ロトム",
+   "ko": "Rot'omu 로토무",
+   "zh": "Luòtuōmǔ 洛托姆",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rotom.png",
+   "obs_code": "pokemon_174590414"
+ },
+ {
+   "code": "Uxie",
+   "en": "Uxie",
+   "de": "Selfe",
+   "fr": "Créhelf",
+   "ja": "Yuxie ユクシー",
+   "ko": "Yuk'ŭsi 유크시",
+   "zh": "Yóukèxī 由克希",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/uxie.png",
+   "obs_code": "pokemon_2087418020"
+ },
+ {
+   "code": "Mesprit",
+   "en": "Mesprit",
+   "de": "Vesprit",
+   "fr": "Créfollet",
+   "ja": "Emrit エムリット",
+   "ko": "Emrait'ŭ 엠라이트",
+   "zh": "Àimǔlìduō 艾姆利多",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mesprit.png",
+   "obs_code": "pokemon_1963882113"
+ },
+ {
+   "code": "Azelf",
+   "en": "Azelf",
+   "de": "Tobutz",
+   "fr": "Créfadet",
+   "ja": "Agnome アグノム",
+   "ko": "Agŭnom 아그놈",
+   "zh": "Yàkènuòmǔ 亞克諾姆",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/azelf.png",
+   "obs_code": "pokemon_171343761"
+ },
+ {
+   "code": "Dialga",
+   "en": "Dialga",
+   "de": "Dialga",
+   "fr": "Dialga",
+   "ja": "Dialga ディアルガ",
+   "ko": "Tiaruga 디아루가",
+   "zh": "Dìyálúkǎ 帝牙盧卡",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dialga.png",
+   "obs_code": "pokemon_1309959811"
+ },
+ {
+   "code": "Palkia",
+   "en": "Palkia",
+   "de": "Palkia",
+   "fr": "Palkia",
+   "ja": "Palkia パルキア",
+   "ko": "P'ŏlgia 펄기아",
+   "zh": "Pàlùqíyá 帕路奇犽",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/palkia.png",
+   "obs_code": "pokemon_1316474619"
+ },
+ {
+   "code": "Heatran",
+   "en": "Heatran",
+   "de": "Heatran",
+   "fr": "Heatran",
+   "ja": "Heatran ヒードラン",
+   "ko": "Hidŭrŏn 히드런",
+   "zh": "Xíduōlán'ēn 席多藍恩",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/heatran.png",
+   "obs_code": "pokemon_3233907712"
+ },
+ {
+   "code": "Regigigas",
+   "en": "Regigigas",
+   "de": "Regigigas",
+   "fr": "Regigigas",
+   "ja": "Regigigas レジギガス",
+   "ko": "Rejigigasŭ 레지기가스",
+   "zh": "Léijíqíkǎsī 雷吉奇卡斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/regigigas.png",
+   "obs_code": "pokemon_1642163143"
+ },
+ {
+   "code": "Giratina (Altered Forme)",
+   "en": "Giratina (Altered Forme)",
+   "de": "Giratina",
+   "fr": "Giratina",
+   "ja": "Giratina ギラティナ",
+   "ko": "Kirat'ina 기라티나",
+   "zh": "Qílādìnà 騎拉帝納",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/giratina-altered.png",
+   "obs_code": "pokemon_4030310056"
+ },
+ {
+   "code": "Cresselia",
+   "en": "Cresselia",
+   "de": "Cresselia",
+   "fr": "Cresselia",
+   "ja": "Crecelia クレセリア",
+   "ko": "K'ŭreseria 크레세리아",
+   "zh": "Kèléisèlìyà 克雷色利亞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cresselia.png",
+   "obs_code": "pokemon_1480424048"
+ },
+ {
+   "code": "Phione",
+   "en": "Phione",
+   "de": "Phione",
+   "fr": "Phione",
+   "ja": "Phione フィオネ",
+   "ko": "P'ione 피오네",
+   "zh": "Fēi'ōunà 霏歐納",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/phione.png",
+   "obs_code": "pokemon_1163489360"
+ },
+ {
+   "code": "Manaphy",
+   "en": "Manaphy",
+   "de": "Manaphy",
+   "fr": "Manaphy",
+   "ja": "Manaphy マナフィ",
+   "ko": "Manap'i 마나피",
+   "zh": "Mǎnàfēi 瑪納霏",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/manaphy.png",
+   "obs_code": "pokemon_826570695"
+ },
+ {
+   "code": "Darkrai",
+   "en": "Darkrai",
+   "de": "Darkrai",
+   "fr": "Darkrai",
+   "ja": "Darkrai ダークライ",
+   "ko": "Tak'ŭrai 다크라이",
+   "zh": "Dákèláiyī 達克萊伊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/darkrai.png",
+   "obs_code": "pokemon_1958633699"
+ },
+ {
+   "code": "Shaymin (Land Forme)",
+   "en": "Shaymin (Land Forme)",
+   "de": "Shaymin",
+   "fr": "Shaymin",
+   "ja": "Sheimi シェイミ",
+   "ko": "Sweimi 쉐이미",
+   "zh": "Jiémī 潔咪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shaymin-land.png",
+   "obs_code": "pokemon_2249683462"
+ },
+ {
+   "code": "Arceus",
+   "en": "Arceus",
+   "de": "Arceus",
+   "fr": "Arceus",
+   "ja": "Arseus アルセウス",
+   "ko": "Arŭseusŭ 아르세우스",
+   "zh": "Ā'ěrzhòusī 阿爾宙斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/arceus.png",
+   "obs_code": "pokemon_2139860310"
+ },
+ {
+   "code": "Victini",
+   "en": "Victini",
+   "de": "Victini",
+   "fr": "Victini",
+   "ja": "Victini ビクティニ",
+   "ko": "Pik'ŭt'ini 비크티니",
+   "zh": "Bǐkètíní 比克提尼",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/victini.png",
+   "obs_code": "pokemon_1435802211"
+ },
+ {
+   "code": "Snivy",
+   "en": "Snivy",
+   "de": "Serpifeu",
+   "fr": "Vipélierre",
+   "ja": "Tsutarja ツタージャ",
+   "ko": "Churibiyan 주리비얀",
+   "zh": "Téngténgshé 藤藤蛇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/snivy.png",
+   "obs_code": "pokemon_197466078"
+ },
+ {
+   "code": "Servine",
+   "en": "Servine",
+   "de": "Efoserp",
+   "fr": "Lianaja",
+   "ja": "Jyanobii ジャノビー",
+   "ko": "Syabi 샤비",
+   "zh": "Qīngténgshé 青藤蛇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/servine.png",
+   "obs_code": "pokemon_4038096757"
+ },
+ {
+   "code": "Serperior",
+   "en": "Serperior",
+   "de": "Serpiroyal",
+   "fr": "Majaspic",
+   "ja": "Jyarohda ジャローダ",
+   "ko": "Syaroda 샤로다",
+   "zh": "Jūnzhǔshé 君主蛇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/serperior.png",
+   "obs_code": "pokemon_144018130"
+ },
+ {
+   "code": "Tepig",
+   "en": "Tepig",
+   "de": "Floink",
+   "fr": "Gruikui",
+   "ja": "Pokabu ポカブ",
+   "ko": "Ttukkuri 뚜꾸리",
+   "zh": "Nuǎnnuǎnzhū 暖暖豬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tepig.png",
+   "obs_code": "pokemon_172303178"
+ },
+ {
+   "code": "Pignite",
+   "en": "Pignite",
+   "de": "Ferkokel",
+   "fr": "Grotichon",
+   "ja": "Chaobuu チャオブー",
+   "ko": "Ch'yaokkul 챠오꿀",
+   "zh": "Chǎochǎozhū 炒炒豬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pignite.png",
+   "obs_code": "pokemon_147874925"
+ },
+ {
+   "code": "Emboar",
+   "en": "Emboar",
+   "de": "Flambirex",
+   "fr": "Roitiflam",
+   "ja": "Enbuoo エンブオー",
+   "ko": "Yeommuwang 염무왕",
+   "zh": "Yánwǔwáng 炎武王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/emboar.png",
+   "obs_code": "pokemon_2129252627"
+ },
+ {
+   "code": "Oshawott",
+   "en": "Oshawott",
+   "de": "Ottaro",
+   "fr": "Moustillon",
+   "ja": "Mijumaru ミジュマル",
+   "ko": "Sudaeng'i 수댕이",
+   "zh": "Shuǐshuǐtà 水水獺",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/oshawott.png",
+   "obs_code": "pokemon_4229204136"
+ },
+ {
+   "code": "Dewott",
+   "en": "Dewott",
+   "de": "Zwottronin",
+   "fr": "Mateloutre",
+   "ja": "Futachimaru フタチマル",
+   "ko": "Ssanggŏmjabi 쌍검자비",
+   "zh": "Shuāngrènwán 雙刃丸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dewott.png",
+   "obs_code": "pokemon_1727391900"
+ },
+ {
+   "code": "Samurott",
+   "en": "Samurott",
+   "de": "Admurai",
+   "fr": "Clamiral",
+   "ja": "Daikenki ダイケンキ",
+   "ko": "Taegŏmgwi 대검귀",
+   "zh": "Dàjiànguǐ 大劍鬼",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/samurott.png",
+   "obs_code": "pokemon_4216145458"
+ },
+ {
+   "code": "Patrat",
+   "en": "Patrat",
+   "de": "Nagelotz",
+   "fr": "Ratentif",
+   "ja": "Minezumi ミネズミ",
+   "ko": "Porŭjwi 보르쥐",
+   "zh": "Tàntànshǔ 探探鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/patrat.png",
+   "obs_code": "pokemon_1741985831"
+ },
+ {
+   "code": "Watchog",
+   "en": "Watchog",
+   "de": "Kukmarda",
+   "fr": "Miradar",
+   "ja": "Miruhoggu ミルホッグ",
+   "ko": "Porŭgŭ 보르그",
+   "zh": "Bùshàoshǔ 步哨鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/watchog.png",
+   "obs_code": "pokemon_3156139812"
+ },
+ {
+   "code": "Lillipup",
+   "en": "Lillipup",
+   "de": "Yorkleff",
+   "fr": "Ponchiot",
+   "ja": "Yooterii ヨーテリー",
+   "ko": "Yot'eri 요테리",
+   "zh": "Xiǎoyuēkè 小約克",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lillipup.png",
+   "obs_code": "pokemon_2564208828"
+ },
+ {
+   "code": "Herdier",
+   "en": "Herdier",
+   "de": "Terribark",
+   "fr": "Ponchien",
+   "ja": "Haderia ハーデリア",
+   "ko": "Haderiŏ 하데리어",
+   "zh": "Hāyuēkè 哈約克",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/herdier.png",
+   "obs_code": "pokemon_1392037248"
+ },
+ {
+   "code": "Stoutland",
+   "en": "Stoutland",
+   "de": "Bissbark",
+   "fr": "Mastouffe",
+   "ja": "Maarando ムーランド",
+   "ko": "Paraendŭ 바랜드",
+   "zh": "Chángmáogǒu 長毛狗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stoutland.png",
+   "obs_code": "pokemon_1807035499"
+ },
+ {
+   "code": "Purrloin",
+   "en": "Purrloin",
+   "de": "Felilou",
+   "fr": "Chacripan",
+   "ja": "Choroneko チョロネコ",
+   "ko": "Ssaebinyang 쌔비냥",
+   "zh": "Páshǒumāo 扒手貓",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/purrloin.png",
+   "obs_code": "pokemon_2008681284"
+ },
+ {
+   "code": "Liepard",
+   "en": "Liepard",
+   "de": "Kleoparda",
+   "fr": "Léopardus",
+   "ja": "Reparudasu レパルダス",
+   "ko": "Rep'arŭdasŭ 레파르다스",
+   "zh": "Kùbào 酷豹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/liepard.png",
+   "obs_code": "pokemon_2989799330"
+ },
+ {
+   "code": "Pansage",
+   "en": "Pansage",
+   "de": "Vegimak",
+   "fr": "Feuillajou",
+   "ja": "Yanappu ヤナップ",
+   "ko": "Yanap'ŭ 야나프",
+   "zh": "Huāyéhóu 花椰猴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pansage.png",
+   "obs_code": "pokemon_4003618858"
+ },
+ {
+   "code": "Simisage",
+   "en": "Simisage",
+   "de": "Vegichita",
+   "fr": "Feuiloutan",
+   "ja": "Yanakki ヤナッキー",
+   "ko": "Yanak'i 야나키",
+   "zh": "Huāyéyuán 花椰猿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/simisage.png",
+   "obs_code": "pokemon_3270642443"
+ },
+ {
+   "code": "Pansear",
+   "en": "Pansear",
+   "de": "Grillmak",
+   "fr": "Flamajou",
+   "ja": "Baoppu バオップ",
+   "ko": "Paop'ŭ 바오프",
+   "zh": "Bàoxiānghóu 爆香猴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pansear.png",
+   "obs_code": "pokemon_1533486655"
+ },
+ {
+   "code": "Simisear",
+   "en": "Simisear",
+   "de": "Grillchita",
+   "fr": "Flamoutan",
+   "ja": "Baokki バオッキー",
+   "ko": "Paok'i 바오키",
+   "zh": "Bàoxiāngyuán 爆香猿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/simisear.png",
+   "obs_code": "pokemon_3360028158"
+ },
+ {
+   "code": "Panpour",
+   "en": "Panpour",
+   "de": "Sodamak",
+   "fr": "Flotajou",
+   "ja": "Hiyappu ヒヤップ",
+   "ko": "Atch'ap'ŭ 앗차프",
+   "zh": "Lěngshuǐhóu 冷水猴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/panpour.png",
+   "obs_code": "pokemon_773278594"
+ },
+ {
+   "code": "Simipour",
+   "en": "Simipour",
+   "de": "Sodachita",
+   "fr": "Flotoutan",
+   "ja": "Hiyakki ヒヤッキー",
+   "ko": "Atch'ak'i 앗차키",
+   "zh": "Lěngshuǐyuán 冷水猿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/simipour.png",
+   "obs_code": "pokemon_4043334307"
+ },
+ {
+   "code": "Munna",
+   "en": "Munna",
+   "de": "Somniam",
+   "fr": "Munna",
+   "ja": "Munna ムンナ",
+   "ko": "Mongna 몽나",
+   "zh": "Shímèngmèng 食夢夢",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/munna.png",
+   "obs_code": "pokemon_169874044"
+ },
+ {
+   "code": "Musharna",
+   "en": "Musharna",
+   "de": "Somnivora",
+   "fr": "Mushana",
+   "ja": "Musharna ムシャーナ",
+   "ko": "Mong'yamna 몽얌나",
+   "zh": "Mèngmèngshí 夢夢蝕",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/musharna.png",
+   "obs_code": "pokemon_2382875610"
+ },
+ {
+   "code": "Pidove",
+   "en": "Pidove",
+   "de": "Dusselgurr",
+   "fr": "Poichigeon",
+   "ja": "Mamepato マメパト",
+   "ko": "K'ongdulgi 콩둘기",
+   "zh": "Dòudòugē 豆豆鴿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pidove.png",
+   "obs_code": "pokemon_1173546340"
+ },
+ {
+   "code": "Tranquill",
+   "en": "Tranquill",
+   "de": "Navitaub",
+   "fr": "Colombeau",
+   "ja": "Hatooboo ハトーポー",
+   "ko": "Yut'obŭ 유토브",
+   "zh": "Bōbōgē 波波鴿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tranquill.png",
+   "obs_code": "pokemon_2488131873"
+ },
+ {
+   "code": "Unfezant",
+   "en": "Unfezant",
+   "de": "Fasasnob",
+   "fr": "Déflaisan",
+   "ja": "Kenhorou ケンホロウ",
+   "ko": "K'enhorou 켄호로우",
+   "zh": "Hōnglóngzhìjī 轟隆雉雞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/unfezant.png",
+   "obs_code": "pokemon_2290930908"
+ },
+ {
+   "code": "Blitzle",
+   "en": "Blitzle",
+   "de": "Elezeba",
+   "fr": "Zébibron",
+   "ja": "Shimama シママ",
+   "ko": "Chulmyuma 줄뮤마",
+   "zh": "Bānbānmǎ 斑斑馬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/blitzle.png",
+   "obs_code": "pokemon_4137631045"
+ },
+ {
+   "code": "Zebstrika",
+   "en": "Zebstrika",
+   "de": "Zebritz",
+   "fr": "Zéblitz",
+   "ja": "Zeburaika ゼブライカ",
+   "ko": "Chebŭraik'a 제브라이카",
+   "zh": "Léidiànbānmǎ 雷電斑馬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zebstrika.png",
+   "obs_code": "pokemon_1016014574"
+ },
+ {
+   "code": "Roggenrola",
+   "en": "Roggenrola",
+   "de": "Kiesling",
+   "fr": "Nodulithe",
+   "ja": "Dangoro ダンゴロ",
+   "ko": "Tangul 단굴",
+   "zh": "Shíwánzi 石丸子",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/roggenrola.png",
+   "obs_code": "pokemon_2377174467"
+ },
+ {
+   "code": "Boldore",
+   "en": "Boldore",
+   "de": "Sedimantur",
+   "fr": "Géolithe",
+   "ja": "Gantoru ガントル",
+   "ko": "Amt'ŭrŭ 암트르",
+   "zh": "Dìmànyán 地幔岩",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/boldore.png",
+   "obs_code": "pokemon_4219953272"
+ },
+ {
+   "code": "Gigalith",
+   "en": "Gigalith",
+   "de": "Brockoloss",
+   "fr": "Gigalithe",
+   "ja": "Gigaias ギガイアス",
+   "ko": "Kigaiŏsŭ 기가이어스",
+   "zh": "Pángyánguài 龐岩怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gigalith.png",
+   "obs_code": "pokemon_1479395572"
+ },
+ {
+   "code": "Woobat",
+   "en": "Woobat",
+   "de": "Fleknoil",
+   "fr": "Chovsourir",
+   "ja": "Koromori コロモリ",
+   "ko": "Ttorŭbakjwi 또르박쥐",
+   "zh": "Gǔngǔnbiānfú 滾滾蝙蝠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/woobat.png",
+   "obs_code": "pokemon_1742544293"
+ },
+ {
+   "code": "Swoobat",
+   "en": "Swoobat",
+   "de": "Fletiamo",
+   "fr": "Rhinolove",
+   "ja": "Kokoromori ココロモリ",
+   "ko": "Mambakjwi 맘박쥐",
+   "zh": "Xīnbiānfú 心蝙蝠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swoobat.png",
+   "obs_code": "pokemon_1669386806"
+ },
+ {
+   "code": "Drilbur",
+   "en": "Drilbur",
+   "de": "Rotomurf",
+   "fr": "Rototaupe",
+   "ja": "Moguryuu モグリュー",
+   "ko": "Tudŏryu 두더류",
+   "zh": "Luódīngdìshǔ 螺釘地鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drilbur.png",
+   "obs_code": "pokemon_750826163"
+ },
+ {
+   "code": "Excadrill",
+   "en": "Excadrill",
+   "de": "Stalobor",
+   "fr": "Minotaupe",
+   "ja": "Doryuuzu ドリュウズ",
+   "ko": "Moldŭryu 몰드류",
+   "zh": "Lóngtóudìshǔ 龍頭地鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/excadrill.png",
+   "obs_code": "pokemon_2621127141"
+ },
+ {
+   "code": "Audino",
+   "en": "Audino",
+   "de": "Ohrdoch",
+   "fr": "Nanméouïe",
+   "ja": "Tabunne タブンネ",
+   "ko": "Tabuni 다부니",
+   "zh": "Chàbùduōwáwá 差不多娃娃",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/audino.png",
+   "obs_code": "pokemon_1683700221"
+ },
+ {
+   "code": "Timburr",
+   "en": "Timburr",
+   "de": "Praktibalk",
+   "fr": "Charpenti",
+   "ja": "Dokkorar ドッコラー",
+   "ko": "Ŭratch'a 으랏차",
+   "zh": "Bānyùnxiǎojiàng 搬運小匠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/timburr.png",
+   "obs_code": "pokemon_662442210"
+ },
+ {
+   "code": "Gurdurr",
+   "en": "Gurdurr",
+   "de": "Strepoli",
+   "fr": "Ouvrifier",
+   "ja": "Dotetsukotsu ドテツコツ",
+   "ko": "T'osoegol 토쇠골",
+   "zh": "Tiěgǔtǔrén 鐵骨土人",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gurdurr.png",
+   "obs_code": "pokemon_662343924"
+ },
+ {
+   "code": "Conkeldurr",
+   "en": "Conkeldurr",
+   "de": "Meistagrif",
+   "fr": "Bétochef",
+   "ja": "Roopushin ローブシン",
+   "ko": "Noboch'ŏng 노보청",
+   "zh": "Xiūshànlǎotóu 修繕老頭",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/conkeldurr.png",
+   "obs_code": "pokemon_791338484"
+ },
+ {
+   "code": "Tympole",
+   "en": "Tympole",
+   "de": "Schallquap",
+   "fr": "Tritonde",
+   "ja": "Otamaro オタマロ",
+   "ko": "Tongch'aeng'i 동챙이",
+   "zh": "Yuánkēdǒu 圓蝌蚪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tympole.png",
+   "obs_code": "pokemon_4114095923"
+ },
+ {
+   "code": "Palpitoad",
+   "en": "Palpitoad",
+   "de": "Mebrana",
+   "fr": "Batracné",
+   "ja": "Gamagaru ガマガル",
+   "ko": "Tukkabi 두까비",
+   "zh": "Lánchánchú 藍蟾蜍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/palpitoad.png",
+   "obs_code": "pokemon_1657885279"
+ },
+ {
+   "code": "Seismitoad",
+   "en": "Seismitoad",
+   "de": "Branawarz",
+   "fr": "Crapustule",
+   "ja": "Gamageroge ガマゲロゲ",
+   "ko": "Tubikkul 두빅굴",
+   "zh": "Chánchúwáng 蟾蜍王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/seismitoad.png",
+   "obs_code": "pokemon_3201503187"
+ },
+ {
+   "code": "Throh",
+   "en": "Throh",
+   "de": "Jiutesto",
+   "fr": "Judokrak",
+   "ja": "Nageki ナゲキ",
+   "ko": "Tŏnjimi 던지미",
+   "zh": "Tóushèguǐ 投射鬼",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/throh.png",
+   "obs_code": "pokemon_177725484"
+ },
+ {
+   "code": "Sawk",
+   "en": "Sawk",
+   "de": "Karadonis",
+   "fr": "Karaclée",
+   "ja": "Dageki ダゲキ",
+   "ko": "T'akkyŏkkwi 타격귀",
+   "zh": "Dǎjíguǐ 打擊鬼",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sawk.png",
+   "obs_code": "pokemon_2088066571"
+ },
+ {
+   "code": "Sewaddle",
+   "en": "Sewaddle",
+   "de": "Strawickl",
+   "fr": "Larveyette",
+   "ja": "Kurumiru クルミル",
+   "ko": "Turŭbo 두르보",
+   "zh": "Chóngbǎobāo 蟲寶包",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sewaddle.png",
+   "obs_code": "pokemon_2726196844"
+ },
+ {
+   "code": "Swadloon",
+   "en": "Swadloon",
+   "de": "Folikon",
+   "fr": "Couverdure",
+   "ja": "Kurumayu クルマユ",
+   "ko": "Turŭk'un 두르쿤",
+   "zh": "Bǎobāojiǎn 寶包繭",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swadloon.png",
+   "obs_code": "pokemon_3724969350"
+ },
+ {
+   "code": "Leavanny",
+   "en": "Leavanny",
+   "de": "Matrifol",
+   "fr": "Manternel",
+   "ja": "Hahakurimo ハハコモリ",
+   "ko": "Moamŏ 모아머",
+   "zh": "Bǎomǔchóng 保母蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/leavanny.png",
+   "obs_code": "pokemon_3677609603"
+ },
+ {
+   "code": "Venipede",
+   "en": "Venipede",
+   "de": "Toxiped",
+   "fr": "Venipatte",
+   "ja": "Fushide フツデ",
+   "ko": "Madine 마디네",
+   "zh": "Bǎizúwúgōng 百足蜈蚣",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/venipede.png",
+   "obs_code": "pokemon_962121605"
+ },
+ {
+   "code": "Whirlipede",
+   "en": "Whirlipede",
+   "de": "Rollum",
+   "fr": "Scobolide",
+   "ja": "Hoiiga ホイーガ",
+   "ko": "Hwilgu 마디네",
+   "zh": "Chēlúnqiú 車輪毬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/whirlipede.png",
+   "obs_code": "pokemon_4075440624"
+ },
+ {
+   "code": "Scolipede",
+   "en": "Scolipede",
+   "de": "Cerapendra",
+   "fr": "Brutapode",
+   "ja": "Pendora ペンドラー",
+   "ko": "P'endŭra 펜드라",
+   "zh": "Wúgōngwáng 蜈蚣王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scolipede.png",
+   "obs_code": "pokemon_1685324843"
+ },
+ {
+   "code": "Cottonee",
+   "en": "Cottonee",
+   "de": "Waumboll",
+   "fr": "Doudouvet",
+   "ja": "Monmen モンメン",
+   "ko": "Somian 소미안",
+   "zh": "Mùmiánqiú 木棉球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cottonee.png",
+   "obs_code": "pokemon_297272200"
+ },
+ {
+   "code": "Whimsicott",
+   "en": "Whimsicott",
+   "de": "Elfun",
+   "fr": "Elfuun",
+   "ja": "Erufuun エルフーン",
+   "ko": "Elp'ung 엘풍",
+   "zh": "Fēngyāojing 風妖精",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/whimsicott.png",
+   "obs_code": "pokemon_1051701160"
+ },
+ {
+   "code": "Petilil",
+   "en": "Petilil",
+   "de": "Lilminip",
+   "fr": "Churine",
+   "ja": "Churine チュリネ",
+   "ko": "Ch'irilli 치릴리",
+   "zh": "Bǎihégēnwáwá 百合根娃娃",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/petilil.png",
+   "obs_code": "pokemon_3916237156"
+ },
+ {
+   "code": "Lilligant",
+   "en": "Lilligant",
+   "de": "Dressella",
+   "fr": "Dredear",
+   "ja": "Doredia ドレディア",
+   "ko": "Tŭrediŏ 드레디어",
+   "zh": "Qún'érxiǎojiě 裙兒小姐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lilligant.png",
+   "obs_code": "pokemon_3329974293"
+ },
+ {
+   "code": "Basculin (Red-Striped Form)",
+   "en": "Basculin (Red-Striped Form)",
+   "de": "Barschuft",
+   "fr": "Bargantua",
+   "ja": "Basurao バスラオ",
+   "ko": "Passŭnai 배쓰나이",
+   "zh": "Yǒngshìlúyú 勇士鱸魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/basculin-red-striped.png",
+   "obs_code": "pokemon_1121322166"
+ },
+ {
+   "code": "Sandile",
+   "en": "Sandile",
+   "de": "Ganovil",
+   "fr": "Mascaïman",
+   "ja": "Meguroko メグロコ",
+   "ko": "Kkamnunk'ŭ 깜눈크",
+   "zh": "Hēiyǎn'è 黑眼鱷",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sandile.png",
+   "obs_code": "pokemon_4111151101"
+ },
+ {
+   "code": "Krokorok",
+   "en": "Krokorok",
+   "de": "Rokkaiman",
+   "fr": "Escroco",
+   "ja": "Warubiru ワルビル",
+   "ko": "Akbirŭ 악비르",
+   "zh": "Hùnhun'è 混混鱷",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/krokorok.png",
+   "obs_code": "pokemon_1337675009"
+ },
+ {
+   "code": "Krookodile",
+   "en": "Krookodile",
+   "de": "Rabigator",
+   "fr": "Crocorible",
+   "ja": "Warubiaru ワルビアル",
+   "ko": "Akbiarŭ 악비아르",
+   "zh": "Liúmáng'è 流氓鱷",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/krookodile.png",
+   "obs_code": "pokemon_4179012380"
+ },
+ {
+   "code": "Darumaka",
+   "en": "Darumaka",
+   "de": "Flampion",
+   "fr": "Darumarond",
+   "ja": "Darumakka ダルマッカ",
+   "ko": "Talmakhwa 달막화",
+   "zh": "Huǒhóngbùdǎowēng 火紅不倒翁",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/darumaka.png",
+   "obs_code": "pokemon_2790810305"
+ },
+ {
+   "code": "Darmanitan (Standard Mode)",
+   "en": "Darmanitan (Standard Mode)",
+   "de": "Flampivian",
+   "fr": "Darumacho",
+   "ja": "Hihidaruma ヒヒダルマ",
+   "ko": "Pulbidalma 불비달마",
+   "zh": "Dámófèifèi 達摩狒狒",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/darmanitan-standard.png",
+   "obs_code": "pokemon_1171909268"
+ },
+ {
+   "code": "Maractus",
+   "en": "Maractus",
+   "de": "Maracamba",
+   "fr": "Maracachi",
+   "ja": "Marakacchi マラカッチ",
+   "ko": "Marak'ach'i 마라카치",
+   "zh": "Jiētóushālíng 街頭沙鈴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/maractus.png",
+   "obs_code": "pokemon_3321005931"
+ },
+ {
+   "code": "Dwebble",
+   "en": "Dwebble",
+   "de": "Lithomith",
+   "fr": "Crabicoque",
+   "ja": "Ishizumai イシズマイ",
+   "ko": "Tolsal'i 돌살이",
+   "zh": "Shíjūxiè 石居蟹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dwebble.png",
+   "obs_code": "pokemon_4128638970"
+ },
+ {
+   "code": "Crustle",
+   "en": "Crustle",
+   "de": "Castellith",
+   "fr": "Crabaraque",
+   "ja": "Iwaparesu イワパレス",
+   "ko": "Amp'aerisŭ 암팰리스",
+   "zh": "Yándiànjūxiè 岩殿居蟹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/crustle.png",
+   "obs_code": "pokemon_4135734575"
+ },
+ {
+   "code": "Scraggy",
+   "en": "Scraggy",
+   "de": "Zurrokex",
+   "fr": "Baggiguane",
+   "ja": "Zuruggu ズルッグ",
+   "ko": "Kon'yullaeng 곤율랭",
+   "zh": "Huátóuxiǎozi 滑頭小子",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scraggy.png",
+   "obs_code": "pokemon_1194323775"
+ },
+ {
+   "code": "Scrafty",
+   "en": "Scrafty",
+   "de": "Irokex",
+   "fr": "Baggaïd",
+   "ja": "Zuruzukin ズルズキン",
+   "ko": "Kon'yulgŏni 곤율거니",
+   "zh": "Tóujīnhùnhun 頭巾混混",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scrafty.png",
+   "obs_code": "pokemon_387640589"
+ },
+ {
+   "code": "Sigilyph",
+   "en": "Sigilyph",
+   "de": "Symvolara",
+   "fr": "Cryptéro",
+   "ja": "Shinpora シンボラー",
+   "ko": "Simborŏ 심보러",
+   "zh": "Xiàngzhēngniǎo 象徵鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sigilyph.png",
+   "obs_code": "pokemon_1714368252"
+ },
+ {
+   "code": "Yamask",
+   "en": "Yamask",
+   "de": "Makabaja",
+   "fr": "Tutafeh",
+   "ja": "Desumasu デスマス",
+   "ko": "Tesŭmasŭ 데스마스",
+   "zh": "Kūkūmiànjù 哭哭面具",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/yamask.png",
+   "obs_code": "pokemon_1871543081"
+ },
+ {
+   "code": "Cofagrigus",
+   "en": "Cofagrigus",
+   "de": "Echnatoll",
+   "fr": "Tutankafer",
+   "ja": "Desukaan デスカーン",
+   "ko": "Tesŭnik'an 데스니칸",
+   "zh": "Sǐshénguān 死神棺",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cofagrigus.png",
+   "obs_code": "pokemon_3749715"
+ },
+ {
+   "code": "Tirtouga",
+   "en": "Tirtouga",
+   "de": "Galapaflos",
+   "fr": "Carapagos",
+   "ja": "Purotooga プロトーガ",
+   "ko": "P'ŭrot'oga 프로토가",
+   "zh": "Yuángàihǎiguī 原蓋海龜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tirtouga.png",
+   "obs_code": "pokemon_971666786"
+ },
+ {
+   "code": "Carracosta",
+   "en": "Carracosta",
+   "de": "Karippas",
+   "fr": "Mégapagos",
+   "ja": "Abagoora アバゴーラ",
+   "ko": "Nŭkkolla 늑골라",
+   "zh": "Lèigǔhǎiguī 肋骨海龜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/carracosta.png",
+   "obs_code": "pokemon_962399372"
+ },
+ {
+   "code": "Archen",
+   "en": "Archen",
+   "de": "Flapteryx",
+   "fr": "Arkéapti",
+   "ja": "Aaken アーケン",
+   "ko": "Ak'en 아켄",
+   "zh": "Shǐzǔxiǎoniǎo 始祖小鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/archen.png",
+   "obs_code": "pokemon_1663901974"
+ },
+ {
+   "code": "Archeops",
+   "en": "Archeops",
+   "de": "Aeropteryx",
+   "fr": "Aéroptéryx",
+   "ja": "Aakeosu アーケオス",
+   "ko": "Ak'eosŭ 아케오스",
+   "zh": "Shǐzǔdàniǎo 始祖大鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/archeops.png",
+   "obs_code": "pokemon_230709204"
+ },
+ {
+   "code": "Trubbish",
+   "en": "Trubbish",
+   "de": "Unratütox",
+   "fr": "Miamiasme",
+   "ja": "Yabukuron ヤブクロン",
+   "ko": "Kkaebong'i 깨봉이",
+   "zh": "Pòpòdài 破破袋",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/trubbish.png",
+   "obs_code": "pokemon_1352953316"
+ },
+ {
+   "code": "Garbodor",
+   "en": "Garbodor",
+   "de": "Deponitox",
+   "fr": "Miasmax",
+   "ja": "Dasutodasu ダストダス",
+   "ko": "Tŏsŭtŭna 더스트나",
+   "zh": "Huīchénshān 灰塵山",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/garbodor.png",
+   "obs_code": "pokemon_1294927781"
+ },
+ {
+   "code": "Zorua",
+   "en": "Zorua",
+   "de": "Zorua",
+   "fr": "Zorua",
+   "ja": "Zorua ゾロア",
+   "ko": "Choroa 조로아",
+   "zh": "Suǒluóyǎ 索羅亞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zorua.png",
+   "obs_code": "pokemon_170186262"
+ },
+ {
+   "code": "Zoroark",
+   "en": "Zoroark",
+   "de": "Zoroark",
+   "fr": "Zoroark",
+   "ja": "Zoroark ゾロアーク",
+   "ko": "Choroak'ŭ 조로아크",
+   "zh": "Suǒluóyǎkè 索羅亞克",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zoroark.png",
+   "obs_code": "pokemon_1371568789"
+ },
+ {
+   "code": "Minccino",
+   "en": "Minccino",
+   "de": "Picochilla",
+   "fr": "Chinchidou",
+   "ja": "Chillarmy チラーミィ",
+   "ko": "Ch'irami 치라미",
+   "zh": "Pàomòlìshǔ 泡沫栗鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/minccino.png",
+   "obs_code": "pokemon_3905570439"
+ },
+ {
+   "code": "Cinccino",
+   "en": "Cinccino",
+   "de": "Chillabell",
+   "fr": "Pashmilla",
+   "ja": "Chirachiino チラチーノ",
+   "ko": "Ch'irach'ino 치라치노",
+   "zh": "Qí​nuò​lìshǔ 奇諾栗鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cinccino.png",
+   "obs_code": "pokemon_3905570441"
+ },
+ {
+   "code": "Gothita",
+   "en": "Gothita",
+   "de": "Mollimorba",
+   "fr": "Scrutella",
+   "ja": "Gochimu ゴチム",
+   "ko": "Kodit'aeng 고디탱",
+   "zh": "Gēdébǎobǎo 哥德寶寶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gothita.png",
+   "obs_code": "pokemon_705886893"
+ },
+ {
+   "code": "Gothorita",
+   "en": "Gothorita",
+   "de": "Hypnomorba",
+   "fr": "Mesmérella",
+   "ja": "Gochimiru ゴチミル",
+   "ko": "Kodibomi 고디보미",
+   "zh": "Gēdéxiǎotóng 哥德小童",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gothorita.png",
+   "obs_code": "pokemon_3832918064"
+ },
+ {
+   "code": "Gothitelle",
+   "en": "Gothitelle",
+   "de": "Morbitesse",
+   "fr": "Sidérella",
+   "ja": "Gochiruzeru ゴチルゼル",
+   "ko": "Kodimoajel 고디모아젤",
+   "zh": "Gēdéxiǎojiě 哥德小姐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gothitelle.png",
+   "obs_code": "pokemon_2943579340"
+ },
+ {
+   "code": "Solosis",
+   "en": "Solosis",
+   "de": "Monozyto",
+   "fr": "Nucléos",
+   "ja": "Yuniran ユニラン",
+   "ko": "Yuniran 유니란",
+   "zh": "Dānluǎnxìbāoqiú 單卵細胞球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/solosis.png",
+   "obs_code": "pokemon_2969919667"
+ },
+ {
+   "code": "Duosion",
+   "en": "Duosion",
+   "de": "Mitodos",
+   "fr": "Méios",
+   "ja": "Daburan ダブラン",
+   "ko": "Tyuran 듀란",
+   "zh": "Shuāngluǎnxìbāoqiú 雙卵細胞球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/duosion.png",
+   "obs_code": "pokemon_2844483360"
+ },
+ {
+   "code": "Reuniclus",
+   "en": "Reuniclus",
+   "de": "Zytomega",
+   "fr": "Symbios",
+   "ja": "Rankurusu ランクルス",
+   "ko": "Rank'ŭllusŭ 란쿨루스",
+   "zh": "Rénzàoxìbāoluǎn 人造細胞卵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/reuniclus.png",
+   "obs_code": "pokemon_468457001"
+ },
+ {
+   "code": "Ducklett",
+   "en": "Ducklett",
+   "de": "Piccolente",
+   "fr": "Couaneton",
+   "ja": "Koaruhii コアルヒー",
+   "ko": "Kkojibori 꼬지보리",
+   "zh": "Yābǎobǎo 鴨寶寶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ducklett.png",
+   "obs_code": "pokemon_3675448629"
+ },
+ {
+   "code": "Swanna",
+   "en": "Swanna",
+   "de": "Swaroness",
+   "fr": "Lakmécygne",
+   "ja": "Swana スワンナ",
+   "ko": "Sŭwanna 스완나",
+   "zh": "Shǒuxítiān'é 首席天鵝",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swanna.png",
+   "obs_code": "pokemon_1310863169"
+ },
+ {
+   "code": "Vanillite",
+   "en": "Vanillite",
+   "de": "Gelatini",
+   "fr": "Sorbébé",
+   "ja": "Banipucchi バニプッチ",
+   "ko": "Panilp'ŭt'i 바닐프티",
+   "zh": "Mínǐbīng 迷你冰",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vanillite.png",
+   "obs_code": "pokemon_2201053901"
+ },
+ {
+   "code": "Vanillish",
+   "en": "Vanillish",
+   "de": "Gelatroppo",
+   "fr": "Sorboul",
+   "ja": "Baniricchi バニリッチ",
+   "ko": "Panillich'i 바닐리치",
+   "zh": "Duōduōbīng 多多冰",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vanillish.png",
+   "obs_code": "pokemon_1779396647"
+ },
+ {
+   "code": "Vanilluxe",
+   "en": "Vanilluxe",
+   "de": "Gelatwino",
+   "fr": "Sorbouboul",
+   "ja": "Baibanira バイバニラ",
+   "ko": "Paebanilla 배바닐라",
+   "zh": "Shuāngbèiduōduōbīng 雙倍多多冰",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vanilluxe.png",
+   "obs_code": "pokemon_816578397"
+ },
+ {
+   "code": "Deerling",
+   "en": "Deerling",
+   "de": "Sesokitz",
+   "fr": "Vivaldaim",
+   "ja": "Shikijika シキジカ",
+   "ko": "Sach'ŏllok 사철록",
+   "zh": "Sìjìlù 四季鹿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/deerling.png",
+   "obs_code": "pokemon_820073343"
+ },
+ {
+   "code": "Sawsbuck",
+   "en": "Sawsbuck",
+   "de": "Kronjuwild",
+   "fr": "Haydaim",
+   "ja": "Mebukijika メブキジカ",
+   "ko": "Parach'ŏllok 바라철록",
+   "zh": "Yáchuīlù 芽吹鹿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sawsbuck.png",
+   "obs_code": "pokemon_3589459852"
+ },
+ {
+   "code": "Emolga",
+   "en": "Emolga",
+   "de": "Emolga",
+   "fr": "Emolga",
+   "ja": "Emonga エモンガ",
+   "ko": "Emongga 에몽가",
+   "zh": "Emongga 導電飛鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/emolga.png",
+   "obs_code": "pokemon_1309949448"
+ },
+ {
+   "code": "Karrablast",
+   "en": "Karrablast",
+   "de": "Laukaps",
+   "fr": "Carabing",
+   "ja": "Kapurumo ガプルモ",
+   "ko": "Ttakjŏnggon 딱정곤",
+   "zh": "Gàigàichóng 蓋蓋蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/karrablast.png",
+   "obs_code": "pokemon_4053452870"
+ },
+ {
+   "code": "Escavalier",
+   "en": "Escavalier",
+   "de": "Cavalanzas",
+   "fr": "Lançargot",
+   "ja": "Shubarugo シュバルゴ",
+   "ko": "Syubarŭgo 슈바르고",
+   "zh": "Qíshìguā'niú 騎士蝸牛",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/escavalier.png",
+   "obs_code": "pokemon_988504788"
+ },
+ {
+   "code": "Foongus",
+   "en": "Foongus",
+   "de": "Tarnpignon",
+   "fr": "Trompignon",
+   "ja": "Tamagetake タマゲタケ",
+   "ko": "Kkamnolbŏsŭl 깜놀버슬",
+   "zh": "Bǎobèiqiúgū 寶貝球菇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/foongus.png",
+   "obs_code": "pokemon_1898440140"
+ },
+ {
+   "code": "Amoonguss",
+   "en": "Amoonguss",
+   "de": "Hutsassa",
+   "fr": "Gaulet",
+   "ja": "Morobareru モロバレル",
+   "ko": "Pporokna 뽀록나",
+   "zh": "Bàolùgū 暴露菇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/amoonguss.png",
+   "obs_code": "pokemon_2091366933"
+ },
+ {
+   "code": "Frillish",
+   "en": "Frillish",
+   "de": "Quabbel",
+   "fr": "Viskuse",
+   "ja": "Pururiru プルリル",
+   "ko": "T'aenggŭril 탱그릴",
+   "zh": "Qīngpiāopiāo 輕飄飄",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/frillish.png",
+   "obs_code": "pokemon_1355426218"
+ },
+ {
+   "code": "Jellicent",
+   "en": "Jellicent",
+   "de": "Apoquallyp",
+   "fr": "Moyade",
+   "ja": "Burunkeru ブルンゲル",
+   "ko": "T'aengt'aenggel 탱탱겔",
+   "zh": "Pàngdūdū 胖嘟嘟",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jellicent.png",
+   "obs_code": "pokemon_2615611167"
+ },
+ {
+   "code": "Alomomola",
+   "en": "Alomomola",
+   "de": "Mamolida",
+   "fr": "Mamanbo",
+   "ja": "Mamambou ママンボウ",
+   "ko": "Mambokch'i 맘복치",
+   "zh": "Bǎomǔmànbō 保母曼波",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/alomomola.png",
+   "obs_code": "pokemon_3767546122"
+ },
+ {
+   "code": "Joltik",
+   "en": "Joltik",
+   "de": "Wattzapf",
+   "fr": "Statitik",
+   "ja": "Bachuru バチュル",
+   "ko": "P'itchook 피쪼옥",
+   "zh": "Diàndiànchóng 電電蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/joltik.png",
+   "obs_code": "pokemon_1841551706"
+ },
+ {
+   "code": "Galvantula",
+   "en": "Galvantula",
+   "de": "Voltula",
+   "fr": "Mygavolt",
+   "ja": "Denchura デンチュラ",
+   "ko": "Chŏnt'ulla 전툴라",
+   "zh": "Diànzhīzhū 電蜘蛛",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/galvantula.png",
+   "obs_code": "pokemon_1174086522"
+ },
+ {
+   "code": "Ferroseed",
+   "en": "Ferroseed",
+   "de": "Kastadur",
+   "fr": "Grindur",
+   "ja": "Tesshiido テッシード",
+   "ko": "Ch'ŏlsidŭ 철시드",
+   "zh": "Zhǒngzǐtiěqiú 種子鐵球",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ferroseed.png",
+   "obs_code": "pokemon_3709469886"
+ },
+ {
+   "code": "Ferrothorn",
+   "en": "Ferrothorn",
+   "de": "Tentantel",
+   "fr": "Noacier",
+   "ja": "Nattorei ナットレイ",
+   "ko": "Nŏt'ŭryŏng 너트령",
+   "zh": "Jiānguǒyǎlíng 堅果啞鈴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ferrothorn.png",
+   "obs_code": "pokemon_393636230"
+ },
+ {
+   "code": "Klink",
+   "en": "Klink",
+   "de": "Klikk",
+   "fr": "Tic",
+   "ja": "Giaru ギアル",
+   "ko": "Kiŏrŭ 기어르",
+   "zh": "Chǐlún'ér 齒輪兒",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/klink.png",
+   "obs_code": "pokemon_185627918"
+ },
+ {
+   "code": "Klang",
+   "en": "Klang",
+   "de": "Kliklak",
+   "fr": "Clic",
+   "ja": "Gigear ギギアル",
+   "ko": "Kigiŏrŭ 기기어르",
+   "zh": "Chǐlúnzǔ 齒輪組",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/klang.png",
+   "obs_code": "pokemon_172250378"
+ },
+ {
+   "code": "Klinklang",
+   "en": "Klinklang",
+   "de": "Klikdiklak",
+   "fr": "Cliticlic",
+   "ja": "Gigigear ギギギアル",
+   "ko": "Kigigiŏrŭ 기기기어르",
+   "zh": "Chǐlúnguài 齒輪怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/klinklang.png",
+   "obs_code": "pokemon_2399638602"
+ },
+ {
+   "code": "Tynamo",
+   "en": "Tynamo",
+   "de": "Zapplardin",
+   "fr": "Anchwatt",
+   "ja": "Shibishirasu シビシラス",
+   "ko": "Chŏriŏ 저리어",
+   "zh": "Mámáxiǎoyú 麻麻小魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tynamo.png",
+   "obs_code": "pokemon_1689071717"
+ },
+ {
+   "code": "Eelektrik",
+   "en": "Eelektrik",
+   "de": "Zapplalek",
+   "fr": "Lampéroie",
+   "ja": "Shibibiiru シビビール",
+   "ko": "Chŏriril 저리릴",
+   "zh": "Mámámán 麻麻鰻",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/eelektrik.png",
+   "obs_code": "pokemon_3627363875"
+ },
+ {
+   "code": "Eelektross",
+   "en": "Eelektross",
+   "de": "Zapplarang",
+   "fr": "Ohmassacre",
+   "ja": "Shibirudon シビルドン",
+   "ko": "Chŏridŏpŭ 저리더프",
+   "zh": "Mámámányúwáng 麻麻鰻魚王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/eelektross.png",
+   "obs_code": "pokemon_2489361614"
+ },
+ {
+   "code": "Elgyem",
+   "en": "Elgyem",
+   "de": "Pygraulon",
+   "fr": "Lewsor",
+   "ja": "Riguree リグレー",
+   "ko": "Rigŭre 리그레",
+   "zh": "Xiǎo​huī​guài​ 小灰怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/elgyem.png",
+   "obs_code": "pokemon_1468911962"
+ },
+ {
+   "code": "Beheeyem",
+   "en": "Beheeyem",
+   "de": "Megalon",
+   "fr": "Neitram",
+   "ja": "Oobemu オーベム",
+   "ko": "Pemk'ŭ 벰크",
+   "zh": "Dàyǔguài 大宇怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/beheeyem.png",
+   "obs_code": "pokemon_1910077915"
+ },
+ {
+   "code": "Litwick",
+   "en": "Litwick",
+   "de": "Lichtel",
+   "fr": "Funécire",
+   "ja": "Hitomoshi ヒトモシ",
+   "ko": "Pulk'yŏmi 불켜미",
+   "zh": "Zhúguānglíng 燭光靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/litwick.png",
+   "obs_code": "pokemon_996507170"
+ },
+ {
+   "code": "Lampent",
+   "en": "Lampent",
+   "de": "Laternecto",
+   "fr": "Mélancolux",
+   "ja": "Ranpuraa ランプラー",
+   "ko": "Raempŭra 램프라",
+   "zh": "Dēnghuǒyōulíng 燈火幽靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lampent.png",
+   "obs_code": "pokemon_2017156138"
+ },
+ {
+   "code": "Chandelure",
+   "en": "Chandelure",
+   "de": "Skelabra",
+   "fr": "Lugulabre",
+   "ja": "Shanderaa シャンデラ",
+   "ko": "Syangdella 샹델라",
+   "zh": "Shuǐjīngdēnghuǒlíng 水晶燈火靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chandelure.png",
+   "obs_code": "pokemon_4275681134"
+ },
+ {
+   "code": "Axew",
+   "en": "Axew",
+   "de": "Milza",
+   "fr": "Coupenotte",
+   "ja": "Kibago キバゴ",
+   "ko": "T'ŏgŏmni 터검니",
+   "zh": "Yáyá 牙牙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/axew.png",
+   "obs_code": "pokemon_2088199534"
+ },
+ {
+   "code": "Fraxure",
+   "en": "Fraxure",
+   "de": "Sharfax",
+   "fr": "Incisache",
+   "ja": "Onondo オノンド",
+   "ko": "Aeksŭndo 액슨도",
+   "zh": "Fǔyálóng 斧牙龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fraxure.png",
+   "obs_code": "pokemon_4190269642"
+ },
+ {
+   "code": "Haxorus",
+   "en": "Haxorus",
+   "de": "Maxax",
+   "fr": "Tranchodon",
+   "ja": "Ononokusu オノノクス",
+   "ko": "Aeksŭraijŭ 액스라이즈",
+   "zh": "Shuāngfǔzhànlóng 雙斧戰龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/haxorus.png",
+   "obs_code": "pokemon_1911574639"
+ },
+ {
+   "code": "Cubchoo",
+   "en": "Cubchoo",
+   "de": "Petznief",
+   "fr": "Polarhume",
+   "ja": "Kumashun クマシュン",
+   "ko": "K'ogomi 코고미",
+   "zh": "Pēntìxióng 噴嚏熊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cubchoo.png",
+   "obs_code": "pokemon_4290738362"
+ },
+ {
+   "code": "Beartic",
+   "en": "Beartic",
+   "de": "Siberio",
+   "fr": "Polagriffe",
+   "ja": "Tsunbeaa ツンベアー",
+   "ko": "T'unbeŏ 툰베어",
+   "zh": "Dòngyuánxióng 凍原熊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/beartic.png",
+   "obs_code": "pokemon_3820060751"
+ },
+ {
+   "code": "Cryogonal",
+   "en": "Cryogonal",
+   "de": "Frigometri",
+   "fr": "Hexagel",
+   "ja": "Furiijio フリージオ",
+   "ko": "P'ŭrijio 프리지오",
+   "zh": "Jǐhéxuěhuā 幾何雪花",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cryogonal.png",
+   "obs_code": "pokemon_1571429353"
+ },
+ {
+   "code": "Shelmet",
+   "en": "Shelmet",
+   "de": "Schnuthelm",
+   "fr": "Escargaume",
+   "ja": "Chobomaki チョボマキ",
+   "ko": "Tchomari 쪼마리",
+   "zh": "Xiǎozuǐguā 小嘴蝸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shelmet.png",
+   "obs_code": "pokemon_1831461355"
+ },
+ {
+   "code": "Accelgor",
+   "en": "Accelgor",
+   "de": "Hydragil",
+   "fr": "Limaspeed",
+   "ja": "Agirudaa アギルダー",
+   "ko": "Ŏjiridŏ 어지리더",
+   "zh": "Mǐnjiéchóng 敏捷蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/accelgor.png",
+   "obs_code": "pokemon_1482573431"
+ },
+ {
+   "code": "Stunfisk",
+   "en": "Stunfisk",
+   "de": "Flunschlik",
+   "fr": "Limonde",
+   "ja": "Maggyo マッギョ",
+   "ko": "Medŏ 메더",
+   "zh": "Níbāyú 泥巴魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stunfisk.png",
+   "obs_code": "pokemon_1991656526"
+ },
+ {
+   "code": "Mienfoo",
+   "en": "Mienfoo",
+   "de": "Lin-Fu",
+   "fr": "Kungfouine",
+   "ja": "Kojofuu コジョフー",
+   "ko": "Pijop'u 비조푸",
+   "zh": "Gōngfuyòu 功夫鼬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mienfoo.png",
+   "obs_code": "pokemon_4274531084"
+ },
+ {
+   "code": "Mienshao",
+   "en": "Mienshao",
+   "de": "Wie-Shu",
+   "fr": "Shaofouine",
+   "ja": "Kojondo コジンド",
+   "ko": "Pijodo 비조도",
+   "zh": "Shīfuyòu 師父鼬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mienshao.png",
+   "obs_code": "pokemon_1983949023"
+ },
+ {
+   "code": "Druddigon",
+   "en": "Druddigon",
+   "de": "Shardrago",
+   "fr": "Drakkarmin",
+   "ja": "Kurimugan クリムガン",
+   "ko": "K'ŭriman 크리만",
+   "zh": "Chìmiànlóng 赤面龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/druddigon.png",
+   "obs_code": "pokemon_1438869129"
+ },
+ {
+   "code": "Golett",
+   "en": "Golett",
+   "de": "Golbit",
+   "fr": "Gringolem",
+   "ja": "Gobitto ゴビット",
+   "ko": "Kolbiram 골비람",
+   "zh": "Ní'ǒuxiǎorén 泥偶小人",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golett.png",
+   "obs_code": "pokemon_1726883396"
+ },
+ {
+   "code": "Golurk",
+   "en": "Golurk",
+   "de": "Golgantes",
+   "fr": "Golemastoc",
+   "ja": "Goruggo ゴルーグ",
+   "ko": "Kollugŭ 골루그",
+   "zh": "Ní'ǒujùrén 泥偶巨人",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golurk.png",
+   "obs_code": "pokemon_1862953389"
+ },
+ {
+   "code": "Pawniard",
+   "en": "Pawniard",
+   "de": "Gladiantri",
+   "fr": "Scalpion",
+   "ja": "Komatana コマタナ",
+   "ko": "Chamangk'al 자망칼",
+   "zh": "Jūdāoxiǎobīng 駒刀小兵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pawniard.png",
+   "obs_code": "pokemon_4210433363"
+ },
+ {
+   "code": "Bisharp",
+   "en": "Bisharp",
+   "de": "Caesurio",
+   "fr": "Scalproie",
+   "ja": "Kirikizan キリキザン",
+   "ko": "Chŏlgakch'am 절각참",
+   "zh": "Pīzhǎnsīlìng 劈斬司令",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bisharp.png",
+   "obs_code": "pokemon_1797899446"
+ },
+ {
+   "code": "Bouffalant",
+   "en": "Bouffalant",
+   "de": "Bisofank",
+   "fr": "Frison",
+   "ja": "Buffalon バッフロン",
+   "ko": "Pŏp'ŭron 버프론",
+   "zh": "Bàobàotóushuǐniú 爆爆頭水牛",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bouffalant.png",
+   "obs_code": "pokemon_4085269099"
+ },
+ {
+   "code": "Rufflet",
+   "en": "Rufflet",
+   "de": "Geronimatz",
+   "fr": "Furaiglon",
+   "ja": "Washibon ワシボン",
+   "ko": "Suridongbo 수리둥보",
+   "zh": "Máotóuxiǎoyīng 毛頭小鷹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rufflet.png",
+   "obs_code": "pokemon_1823597855"
+ },
+ {
+   "code": "Braviary",
+   "en": "Braviary",
+   "de": "Washakwil",
+   "fr": "Gueriaigle",
+   "ja": "Wooguru ウォーグル",
+   "ko": "Wŏgŭl 워글",
+   "zh": "Yǒngshìyīng 勇士鷹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/braviary.png",
+   "obs_code": "pokemon_2211408001"
+ },
+ {
+   "code": "Vullaby",
+   "en": "Vullaby",
+   "de": "Skallyk",
+   "fr": "Vostourno",
+   "ja": "Baruchai バルチャイ",
+   "ko": "Pŏlch'ai 벌차이",
+   "zh": "Tūyīngxiǎozi 禿鷹小子",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vullaby.png",
+   "obs_code": "pokemon_1083450044"
+ },
+ {
+   "code": "Mandibuzz",
+   "en": "Mandibuzz",
+   "de": "Grypheldis",
+   "fr": "Vaututrice",
+   "ja": "Barujiina バルジーナ",
+   "ko": "Pŏraenjina 버랜지나",
+   "zh": "Tūyīngnà 禿鷹娜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mandibuzz.png",
+   "obs_code": "pokemon_945188477"
+ },
+ {
+   "code": "Heatmor",
+   "en": "Heatmor",
+   "de": "Furnifraß",
+   "fr": "Aflamanoir",
+   "ja": "Kuitaran クイタラン",
+   "ko": "Aent'igol 앤티골",
+   "zh": "Shíyǐlú 食蟻爐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/heatmor.png",
+   "obs_code": "pokemon_1459835533"
+ },
+ {
+   "code": "Durant",
+   "en": "Durant",
+   "de": "Fermicula",
+   "fr": "Fermite",
+   "ja": "Aianto アイアント",
+   "ko": "Aiaent'ŭ 아이앤트",
+   "zh": "Tiěyǐ 鐵蟻",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/durant.png",
+   "obs_code": "pokemon_1753229085"
+ },
+ {
+   "code": "Deino",
+   "en": "Deino",
+   "de": "Kapuno",
+   "fr": "Solochi",
+   "ja": "Monozu モノズ",
+   "ko": "Monodu 모노두",
+   "zh": "Dānshǒulóng 單首龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/deino.png",
+   "obs_code": "pokemon_181171756"
+ },
+ {
+   "code": "Zweilous",
+   "en": "Zweilous",
+   "de": "Duodino",
+   "fr": "Diamat",
+   "ja": "Jiheddo ジヘッド",
+   "ko": "Tihedŭ 디헤드",
+   "zh": "Shuāng​tóulóng 雙頭龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zweilous.png",
+   "obs_code": "pokemon_2806481089"
+ },
+ {
+   "code": "Hydreigon",
+   "en": "Hydreigon",
+   "de": "Trikephalo",
+   "fr": "Trioxhydre",
+   "ja": "Sazando サザンド",
+   "ko": "Samsamdŭrae 삼삼드래",
+   "zh": "Sāntóulóng 三頭龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hydreigon.png",
+   "obs_code": "pokemon_1438235176"
+ },
+ {
+   "code": "Larvesta",
+   "en": "Larvesta",
+   "de": "Ignivor",
+   "fr": "Pyronille",
+   "ja": "Meraruba メラルバ",
+   "ko": "Hwalhwarŭba 활화르바",
+   "zh": "Rán​shāo​chóng​ 燃燒蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/larvesta.png",
+   "obs_code": "pokemon_1126365295"
+ },
+ {
+   "code": "Volcarona",
+   "en": "Volcarona",
+   "de": "Ramoth",
+   "fr": "Pyrax",
+   "ja": "Urugamosu ウルガモス",
+   "ko": "Pulk'amosŭ 불카모스",
+   "zh": "Huǒshén​chóng​ 火神蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/volcarona.png",
+   "obs_code": "pokemon_650991424"
+ },
+ {
+   "code": "Cobalion",
+   "en": "Cobalion",
+   "de": "Kobalium",
+   "fr": "Cobaltium",
+   "ja": "Kobaruon コバルオン",
+   "ko": "K'obarŭon 코바르온",
+   "zh": "Gōupàlùwēng 勾帕路翁",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cobalion.png",
+   "obs_code": "pokemon_3641998318"
+ },
+ {
+   "code": "Terrakion",
+   "en": "Terrakion",
+   "de": "Terrakium",
+   "fr": "Terrakium",
+   "ja": "Terakion テラキオン",
+   "ko": "T'erak'ion 테라키온",
+   "zh": "Dàilājīwēng 代拉基翁",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/terrakion.png",
+   "obs_code": "pokemon_44742262"
+ },
+ {
+   "code": "Virizion",
+   "en": "Virizion",
+   "de": "Viridium",
+   "fr": "Viridium",
+   "ja": "Birijion ビリジオン",
+   "ko": "Piridion 비리디온",
+   "zh": "Bìlìjíwēng 畢力吉翁",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/virizion.png",
+   "obs_code": "pokemon_3672949299"
+ },
+ {
+   "code": "Tornadus (Incarnate Forme)",
+   "en": "Tornadus (Incarnate Forme)",
+   "de": "Boreos",
+   "fr": "Boréas",
+   "ja": "Torunerosu トルネロス",
+   "ko": "T'onerosŭ 토네로스",
+   "zh": "Lóngjuǎnyún 龍捲雲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tornadus-incarnate.png",
+   "obs_code": "pokemon_1653274245"
+ },
+ {
+   "code": "Thundurus (Incarnate Forme)",
+   "en": "Thundurus (Incarnate Forme)",
+   "de": "Voltolos",
+   "fr": "Fulguris",
+   "ja": "Borutorosu ボルトロス",
+   "ko": "Polt'ŭrosŭ 볼트로스",
+   "zh": "Léidiànyún 雷電雲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/thundurus-incarnate.png",
+   "obs_code": "pokemon_419211971"
+ },
+ {
+   "code": "Reshiram",
+   "en": "Reshiram",
+   "de": "Reshiram",
+   "fr": "Reshiram",
+   "ja": "Reshiram レシラム",
+   "ko": "Resiramu 레시라무",
+   "zh": "Léixīlāmǔ 雷希拉姆",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/reshiram.png",
+   "obs_code": "pokemon_1543204894"
+ },
+ {
+   "code": "Zekrom",
+   "en": "Zekrom",
+   "de": "Zekrom",
+   "fr": "Zekrom",
+   "ja": "Zekrom ゼクロム",
+   "ko": "Chek'ŭromu 제크로무",
+   "zh": "Jiékèluómǔ 捷克羅姆",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zekrom.png",
+   "obs_code": "pokemon_1466728001"
+ },
+ {
+   "code": "Landorus (Incarnate Forme)",
+   "en": "Landorus (Incarnate Forme)",
+   "de": "Demeteros",
+   "fr": "Démétéros",
+   "ja": "Randorosu ランドロス",
+   "ko": "Raendŭrosŭ 랜드로스",
+   "zh": "Tǔdìyún 土地雲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/landorus-incarnate.png",
+   "obs_code": "pokemon_2520970589"
+ },
+ {
+   "code": "Kyurem",
+   "en": "Kyurem",
+   "de": "Kyurem",
+   "fr": "Kyurem",
+   "ja": "Kyuremu キュレム",
+   "ko": "K'yuremu 큐레무",
+   "zh": "Qiúléimǔ 酋雷姆",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kyurem.png",
+   "obs_code": "pokemon_1469355096"
+ },
+ {
+   "code": "Keldeo (Ordinary Forme)",
+   "en": "Keldeo (Ordinary Forme)",
+   "de": "Keldeo",
+   "fr": "Keldeo",
+   "ja": "Kerudio ケルディオ",
+   "ko": "K'erŭdio 케르디오",
+   "zh": "Kǎilùdí'ōu 凱路迪歐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/keldeo-ordinary.png",
+   "obs_code": "pokemon_3944089648"
+ },
+ {
+   "code": "Meloetta (Aria Forme)",
+   "en": "Meloetta (Aria Forme)",
+   "de": "Meloetta",
+   "fr": "Meloetta",
+   "ja": "Meloia メロエッタ",
+   "ko": "Mero'ett'a 메로엣타",
+   "zh": "Měiluòyétǎ 美洛耶塔",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meloetta-aria.png",
+   "obs_code": "pokemon_3254295932"
+ },
+ {
+   "code": "Genesect",
+   "en": "Genesect",
+   "de": "Genesect",
+   "fr": "Genesect",
+   "ja": "Genosekuto ゲノセクト",
+   "ko": "Kenosek'ŭt'ŭ 게노세크트",
+   "zh": "Gàinuòsàikètè 蓋諾賽克特",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/genesect.png",
+   "obs_code": "pokemon_1281878253"
+ },
+ {
+   "code": "Chespin",
+   "en": "Chespin",
+   "de": "Igamaro",
+   "fr": "Marisson",
+   "ja": "Harimaron ハリマロン",
+   "ko": "Dochimaron 도치마론",
+   "zh": "Hālìlì 哈力栗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chespin.png",
+   "obs_code": "pokemon_2927410191"
+ },
+ {
+   "code": "Quilladin",
+   "en": "Quilladin",
+   "de": "Igastarnish",
+   "fr": "Boguérisse",
+   "ja": "Hariboogu ハリボーグ",
+   "ko": "Dochibogu 도치보구",
+   "zh": "胖胖哈力",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/quilladin.png",
+   "obs_code": "pokemon_3621054890"
+ },
+ {
+   "code": "Chesnaught",
+   "en": "Chesnaught",
+   "de": "Brigaron",
+   "fr": "Blindépique",
+   "ja": "Burigaron ブリガロン",
+   "ko": "Beurigaron 브리가론",
+   "zh": "Bùlǐkǎlóng 布里卡隆",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/chesnaught.png",
+   "obs_code": "pokemon_3582880185"
+ },
+ {
+   "code": "Fennekin",
+   "en": "Fennekin",
+   "de": "Fynx",
+   "fr": "Feunnec",
+   "ja": "Focko フォッコ",
+   "ko": "Puho'kko 푸호꼬",
+   "zh": "Huǒhúlí 火狐狸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fennekin.png",
+   "obs_code": "pokemon_1862054159"
+ },
+ {
+   "code": "Braixen",
+   "en": "Braixen",
+   "de": "Rutena",
+   "fr": "Roussil",
+   "ja": "Teerunaa テールナー",
+   "ko": "Tereuna 테르나",
+   "zh": "Chángwěihuǒhú 长尾火狐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/braixen.png",
+   "obs_code": "pokemon_3388616078"
+ },
+ {
+   "code": "Delphox",
+   "en": "Delphox",
+   "de": "Fennexis",
+   "fr": "Goupelin",
+   "ja": "Mafoxy マフォクシー",
+   "ko": "Mapoksi 마폭시",
+   "zh": "Yāohuǒhónghú 妖火紅狐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/delphox.png",
+   "obs_code": "pokemon_3740569479"
+ },
+ {
+   "code": "Froakie",
+   "en": "Froakie",
+   "de": "Froxy",
+   "fr": "Grenousse",
+   "ja": "Keromatsu ケロマツ",
+   "ko": "Gaegumareu 개구마르",
+   "zh": "Guāguāpàowā 呱呱泡蛙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/froakie.png",
+   "obs_code": "pokemon_3917883480"
+ },
+ {
+   "code": "Frogadier",
+   "en": "Frogadier",
+   "de": "Amphizel",
+   "fr": "Croâporal",
+   "ja": "Gekogashira ゲコガシラ",
+   "ko": "Gaegulbanjang 개굴반장",
+   "zh": "呱头蛙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/frogadier.png",
+   "obs_code": "pokemon_4117939394"
+ },
+ {
+   "code": "Greninja",
+   "en": "Greninja",
+   "de": "Quajutsu",
+   "fr": "Amphinobi",
+   "ja": "Gekkōga ゲッコウガ",
+   "ko": "Gaegulninja 개굴닌자",
+   "zh": "Jiǎhèrěnwā 甲賀忍蛙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/greninja.png",
+   "obs_code": "pokemon_2167559287"
+ },
+ {
+   "code": "Bunnelby",
+   "en": "Bunnelby",
+   "de": "Scoppel",
+   "fr": "Sapereau",
+   "ja": "Horubii ホルビー",
+   "ko": "Pareubit 파르빗",
+   "zh": "Juéjuétù 掘掘兔",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bunnelby.png",
+   "obs_code": "pokemon_988181504"
+ },
+ {
+   "code": "Diggersby",
+   "en": "Diggersby",
+   "de": "Grebbit",
+   "fr": "Excavarenne",
+   "ja": "Horūdo ホルード",
+   "ko": "Pareuto 파르토",
+   "zh": "Huōtǔtù 攉土兔",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/diggersby.png",
+   "obs_code": "pokemon_3312413655"
+ },
+ {
+   "code": "Fletchling",
+   "en": "Fletchling",
+   "de": "Dartiri",
+   "fr": "Passerouge",
+   "ja": "Yayakoma ヤヤコマ",
+   "ko": "Hwasal'kkobin 화살꼬빈",
+   "zh": "Xiǎojiànquè 小箭雀",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fletchling.png",
+   "obs_code": "pokemon_3138896729"
+ },
+ {
+   "code": "Fletchinder",
+   "en": "Fletchinder",
+   "de": "Dartignis",
+   "fr": "Braisillon",
+   "ja": "Hinoyakoma ヒノヤコマ",
+   "ko": "Bulhwasalbin 불화살빈",
+   "zh": "Huǒjiànquè 火箭雀",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fletchinder.png",
+   "obs_code": "pokemon_1366629665"
+ },
+ {
+   "code": "Talonflame",
+   "en": "Talonflame",
+   "de": "Fiaro",
+   "fr": "Flambusard",
+   "ja": "Faiarō ファイアロー",
+   "ko": "Pai'eoro 파이어로",
+   "zh": "lièjiànwēng 烈箭鹟",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/talonflame.png",
+   "obs_code": "pokemon_1233626718"
+ },
+ {
+   "code": "Scatterbug",
+   "en": "Scatterbug",
+   "de": "Purmel",
+   "fr": "Lépidonille",
+   "ja": "Kofukimushi コフキムシ",
+   "ko": "Bun'ibeolle 분이벌레",
+   "zh": "Fěnyǒng 粉蛹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/scatterbug.png",
+   "obs_code": "pokemon_2317839667"
+ },
+ {
+   "code": "Spewpa",
+   "en": "Spewpa",
+   "de": "Puponcho",
+   "fr": "Pérégrain",
+   "ja": "Kofūrai コフーライ",
+   "ko": "Bun'ddeodori 분떠도리",
+   "zh": "Fěndiéyǒng 粉蝶蛹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spewpa.png",
+   "obs_code": "pokemon_1326859589"
+ },
+ {
+   "code": "Vivillon",
+   "en": "Vivillon",
+   "de": "Vivillon",
+   "fr": "Prismillon",
+   "ja": "Vivillon ビビヨン",
+   "ko": "Bibiyong 비비용",
+   "zh": "Bìfěndié 碧粉蝶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vivillon.png",
+   "obs_code": "pokemon_3532009668"
+ },
+ {
+   "code": "Litleo",
+   "en": "Litleo",
+   "de": "Leufeo",
+   "fr": "Hélionceau",
+   "ja": "Shishiko シシコ",
+   "ko": "Re'okko 레오꼬",
+   "zh": "Xiǎoshīshī 小獅獅",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/litleo.png",
+   "obs_code": "pokemon_1698387986"
+ },
+ {
+   "code": "Pyroar",
+   "en": "Pyroar",
+   "de": "Pyroleo",
+   "fr": "Némélios",
+   "ja": "Kaenjishi カエンジシ",
+   "ko": "Hwayeomre'o 화염레오",
+   "zh": "Huǒyánshī 火炎獅",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pyroar.png",
+   "obs_code": "pokemon_2129235586"
+ },
+ {
+   "code": "Flabébé",
+   "en": "Flabébé",
+   "de": "Flabébé",
+   "fr": "Flabébé",
+   "ja": "Furabebe フラベベ",
+   "ko": "Peullabebe 플라베베",
+   "zh": "Huābèibèi 花蓓蓓",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/flabebe.png",
+   "obs_code": "pokemon_3582283854"
+ },
+ {
+   "code": "Floette",
+   "en": "Floette",
+   "de": "Floette",
+   "fr": "Floette",
+   "ja": "Floette フラエッテ",
+   "ko": "Peuraette 플라엣테",
+   "zh": "花叶蒂",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/floette.png",
+   "obs_code": "pokemon_116389408"
+ },
+ {
+   "code": "Florges",
+   "en": "Florges",
+   "de": "Florges",
+   "fr": "Florges",
+   "ja": "Florges フラージェス",
+   "ko": "Peurajeseu 플라제스",
+   "zh": "Huājiéfūren 花洁夫人",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/florges.png",
+   "obs_code": "pokemon_2523896163"
+ },
+ {
+   "code": "Skiddo",
+   "en": "Skiddo",
+   "de": "Mähikel",
+   "fr": "Cabriolaine",
+   "ja": "Meekuru メェークル",
+   "ko": "Meikeul 메이클",
+   "zh": "Miēmiēyáng 咩咩羊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skiddo.png",
+   "obs_code": "pokemon_1699760219"
+ },
+ {
+   "code": "Gogoat",
+   "en": "Gogoat",
+   "de": "Chevrumm",
+   "fr": "Chevroum",
+   "ja": "Gogoat ゴーゴート",
+   "ko": "Gogoteu 고고트",
+   "zh": "Zuòqíshānyáng 坐騎山羊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gogoat.png",
+   "obs_code": "pokemon_1742926800"
+ },
+ {
+   "code": "Pancham",
+   "en": "Pancham",
+   "de": "Pam-Pam",
+   "fr": "Pandespiegle",
+   "ja": "Yancham ヤンチャム",
+   "ko": "Pan'jjang 판짱",
+   "zh": "Wánpíxióngmāo 頑皮熊貓",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pancham.png",
+   "obs_code": "pokemon_1052756861"
+ },
+ {
+   "code": "Pangoro",
+   "en": "Pangoro",
+   "de": "Pandagro",
+   "fr": "Pandarbare",
+   "ja": "Goronda ゴロンダ",
+   "ko": "Buranda 부란다",
+   "zh": "Liúmángxióngmāo 流氓熊貓",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pangoro.png",
+   "obs_code": "pokemon_493874895"
+ },
+ {
+   "code": "Furfrou",
+   "en": "Furfrou",
+   "de": "Coiffwaff",
+   "fr": "Couafarel",
+   "ja": "Torimian トリミアン",
+   "ko": "Teurimiang 트리미앙",
+   "zh": "Duōlìmǐyà 多麗米亞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/furfrou.png",
+   "obs_code": "pokemon_3486961610"
+ },
+ {
+   "code": "Espurr",
+   "en": "Espurr",
+   "de": "Psiau",
+   "fr": "Psystigri",
+   "ja": "Nyasupā ニャスパー",
+   "ko": "Nyaseupeo 냐스퍼",
+   "zh": "Miàomiāo 妙喵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/espurr.png",
+   "obs_code": "pokemon_2102458646"
+ },
+ {
+   "code": "Meowstic (Male)",
+   "en": "Meowstic (Male)",
+   "de": "Psiaugon",
+   "fr": "Mistigrix",
+   "ja": "Nyaonikusu ニャオニクス",
+   "ko": "Nyaonikseu 냐오닉스",
+   "zh": "Chāonéngmiàomiāo 超能妙喵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meowstic-male.png",
+   "obs_code": "pokemon_2329455504"
+ },
+ {
+   "code": "Honedge",
+   "en": "Honedge",
+   "de": "Gramokles",
+   "fr": "Monorpale",
+   "ja": "Hitotsuki ヒトツキ",
+   "ko": "Dankalbing 단칼빙",
+   "zh": "Dújiànqiào 獨劍鞘",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/honedge.png",
+   "obs_code": "pokemon_3997331887"
+ },
+ {
+   "code": "Doublade",
+   "en": "Doublade",
+   "de": "Duokles",
+   "fr": "Dimoclès",
+   "ja": "Nidangiru ニダンギル",
+   "ko": "Ssanggeomkil 쌍검킬",
+   "zh": "Shuāngjiànqiào 雙劍鞘",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/doublade.png",
+   "obs_code": "pokemon_1104351221"
+ },
+ {
+   "code": "Aegislash (Blade Forme)",
+   "en": "Aegislash (Blade Forme)",
+   "de": "Durengard",
+   "fr": "Exagide",
+   "ja": "Girugarudo ギルガルド",
+   "ko": "Kilgareudo 킬가르도",
+   "zh": "Jiāndùnjiànguài 堅盾劍怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aegislash-blade.png",
+   "obs_code": "pokemon_1540721929"
+ },
+ {
+   "code": "Spritzee",
+   "en": "Spritzee",
+   "de": "Parfi",
+   "fr": "Fluvetin",
+   "ja": "Shushupu シュシュプ",
+   "ko": "Syuppeu 슈쁘",
+   "zh": "Fěnxiāngxiāng 粉香香",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/spritzee.png",
+   "obs_code": "pokemon_1065933203"
+ },
+ {
+   "code": "Aromatisse",
+   "en": "Aromatisse",
+   "de": "Parfinesse",
+   "fr": "Cocotine",
+   "ja": "Furefuwan フレフワン",
+   "ko": "Peurepeutireu 프레프티르",
+   "zh": "Fāngxiāngjīng 芳香精",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aromatisse.png",
+   "obs_code": "pokemon_299710509"
+ },
+ {
+   "code": "Swirlix",
+   "en": "Swirlix",
+   "de": "Flauschling",
+   "fr": "Sucroquin",
+   "ja": "Peropuff ペロッパフ",
+   "ko": "Narumpeopeu 나룸퍼프",
+   "zh": "Miánmiánpàofú 綿綿泡芙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/swirlix.png",
+   "obs_code": "pokemon_3965970055"
+ },
+ {
+   "code": "Slurpuff",
+   "en": "Slurpuff",
+   "de": "Sabbaione",
+   "fr": "Cupcanaille",
+   "ja": "Perorimu ペロリーム",
+   "ko": "Narurim 나루림",
+   "zh": "Pàngtiánnī 胖甜妮",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/slurpuff.png",
+   "obs_code": "pokemon_2749106488"
+ },
+ {
+   "code": "Inkay",
+   "en": "Inkay",
+   "de": "Iscalar",
+   "fr": "Sepiatop",
+   "ja": "Maika マーイーカ",
+   "ko": "Okeijing 오케이징",
+   "zh": "Háolǎhuāzhī 豪喇花枝",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/inkay.png",
+   "obs_code": "pokemon_198218353"
+ },
+ {
+   "code": "Malamar",
+   "en": "Malamar",
+   "de": "Calamanero",
+   "fr": "Sepiatroce",
+   "ja": "Karamanero カラマネロ",
+   "ko": "Kallamanero 칼라마네로",
+   "zh": "乌贼王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/malamar.png",
+   "obs_code": "pokemon_1543457786"
+ },
+ {
+   "code": "Binacle",
+   "en": "Binacle",
+   "de": "Bithora",
+   "fr": "Opermine",
+   "ja": "Kametete カメテテ",
+   "ko": "Geoboksonson 거북손손",
+   "zh": "龟脚脚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/binacle.png",
+   "obs_code": "pokemon_4127753291"
+ },
+ {
+   "code": "Barbaracle",
+   "en": "Barbaracle",
+   "de": "Thanathora",
+   "fr": "Golgopathe",
+   "ja": "Gamenodesu ガメノデス",
+   "ko": "Geoboksondeseu 거북손데스",
+   "zh": "龟足巨铠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/barbaracle.png",
+   "obs_code": "pokemon_575865198"
+ },
+ {
+   "code": "Skrelp",
+   "en": "Skrelp",
+   "de": "Algitt",
+   "fr": "Venalgue",
+   "ja": "Kuzumō クズモー",
+   "ko": "Suregi 수레기",
+   "zh": "Lālāzǎo 垃垃藻",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/skrelp.png",
+   "obs_code": "pokemon_1902654678"
+ },
+ {
+   "code": "Dragalge",
+   "en": "Dragalge",
+   "de": "Tandrak",
+   "fr": "Kravarech",
+   "ja": "Doramidoro ドラミドロ",
+   "ko": "Deuraekam 드래캄",
+   "zh": "Dúlāmìnī 毒拉蜜妮",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dragalge.png",
+   "obs_code": "pokemon_3371239322"
+ },
+ {
+   "code": "Clauncher",
+   "en": "Clauncher",
+   "de": "Scampisto",
+   "fr": "Flingouste",
+   "ja": "Udeppō ウデッポウ",
+   "ko": "Wancheolpo 완철포",
+   "zh": "铁臂枪虾",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/clauncher.png",
+   "obs_code": "pokemon_606513836"
+ },
+ {
+   "code": "Clawitzer",
+   "en": "Clawitzer",
+   "de": "Wummer",
+   "fr": "Gamblast",
+   "ja": "Burosutā ブロスター",
+   "ko": "Beulloseuteo 블로스터",
+   "zh": "钢砲臂虾",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/clawitzer.png",
+   "obs_code": "pokemon_3466181068"
+ },
+ {
+   "code": "Helioptile",
+   "en": "Helioptile",
+   "de": "Eguana",
+   "fr": "Galvaran",
+   "ja": "Elikiteru エリキテル",
+   "ko": "Mokdorikitel 목도리키텔",
+   "zh": "Sǎndiànxī 傘電蜥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/helioptile.png",
+   "obs_code": "pokemon_2026180358"
+ },
+ {
+   "code": "Heliolisk",
+   "en": "Heliolisk",
+   "de": "Elezard",
+   "fr": "Iguolta",
+   "ja": "Erezādo エレザード",
+   "ko": "Illedorijadeu 일레도리자드",
+   "zh": "Diànsǎnchátè 電傘查特",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/heliolisk.png",
+   "obs_code": "pokemon_1672319231"
+ },
+ {
+   "code": "Tyrunt",
+   "en": "Tyrunt",
+   "de": "Balgoras",
+   "fr": "Ptyranidur",
+   "ja": "Chigorasu チゴラス",
+   "ko": "Tigoraseu 티고라스",
+   "zh": "Bǎobǎobàolóng 寶寶暴龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tyrunt.png",
+   "obs_code": "pokemon_1752544021"
+ },
+ {
+   "code": "Tyrantrum",
+   "en": "Tyrantrum",
+   "de": "Monargoras",
+   "fr": "Rexillius",
+   "ja": "Gachigorasu ガチゴラス",
+   "ko": "Gyeongoraseu 견고라스",
+   "zh": "Guàièlóng 怪颚龙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tyrantrum.png",
+   "obs_code": "pokemon_3699421611"
+ },
+ {
+   "code": "Amaura",
+   "en": "Amaura",
+   "de": "Amarino",
+   "fr": "Amagara",
+   "ja": "Amarusu アマルス",
+   "ko": "Amaruseu 아마루스",
+   "zh": "Bīngxuělóng 冰雪龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/amaura.png",
+   "obs_code": "pokemon_1324411630"
+ },
+ {
+   "code": "Aurorus",
+   "en": "Aurorus",
+   "de": "Amagarga",
+   "fr": "Dragmara",
+   "ja": "Amaruruga アマルルガ",
+   "ko": "Amarureuga 아마루르가",
+   "zh": "Bīngxuějùlóng 冰雪巨龙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/aurorus.png",
+   "obs_code": "pokemon_1911585784"
+ },
+ {
+   "code": "Sylveon",
+   "en": "Sylveon",
+   "de": "Feelinara",
+   "fr": "Nymphali",
+   "ja": "Nymphia ニンフィア",
+   "ko": "Nymphia 님피아",
+   "zh": "Xiānzǐjīnglíng 仙子精靈",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sylveon.png",
+   "obs_code": "pokemon_2830657041"
+ },
+ {
+   "code": "Hawlucha",
+   "en": "Hawlucha",
+   "de": "Resladero",
+   "fr": "Brutalibré",
+   "ja": "Ruchaburu ルチャブル",
+   "ko": "Ruchabul 루차불",
+   "zh": "Zhàndòufēiniǎo 戰鬥飛鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hawlucha.png",
+   "obs_code": "pokemon_890740840"
+ },
+ {
+   "code": "Dedenne",
+   "en": "Dedenne",
+   "de": "Dedenne",
+   "fr": "Dedenne",
+   "ja": "Dedenne デデンネ",
+   "ko": "Dedenne 데덴네",
+   "zh": "Dōngdōngshǔ 咚咚鼠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dedenne.png",
+   "obs_code": "pokemon_4036598016"
+ },
+ {
+   "code": "Carbink",
+   "en": "Carbink",
+   "de": "Rocara",
+   "fr": "Strassie",
+   "ja": "Mereshī メレシー",
+   "ko": "Mellisi 멜리시",
+   "zh": "Xiǎosuìzuàn 小碎鑽",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/carbink.png",
+   "obs_code": "pokemon_285697147"
+ },
+ {
+   "code": "Goomy",
+   "en": "Goomy",
+   "de": "Viscora",
+   "fr": "Mucuscule",
+   "ja": "Numera ヌメラ",
+   "ko": "Mikkeumera 미끄메라",
+   "zh": "Niánniánbǎo 黏黏宝",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/goomy.png",
+   "obs_code": "pokemon_197808342"
+ },
+ {
+   "code": "Sliggoo",
+   "en": "Sliggoo",
+   "de": "Viscargot",
+   "fr": "Colimucus",
+   "ja": "Numeiru ヌメイル",
+   "ko": "Mikkeunaeil 미끄네일",
+   "zh": "黏美伊儿",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sliggoo.png",
+   "obs_code": "pokemon_4275338899"
+ },
+ {
+   "code": "Goodra",
+   "en": "Goodra",
+   "de": "Viscogon",
+   "fr": "Muplodocus",
+   "ja": "Numerugon ヌメルゴン",
+   "ko": "Mikkeuraegon 미끄래곤",
+   "zh": "黏美露龙",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/goodra.png",
+   "obs_code": "pokemon_1325032469"
+ },
+ {
+   "code": "Klefki",
+   "en": "Klefki",
+   "de": "Clavion",
+   "fr": "Trousselin",
+   "ja": "Kureffi クレッフィ",
+   "ko": "Keullepi 클레피",
+   "zh": "Yàoquān'ér 鑰圈兒",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/klefki.png",
+   "obs_code": "pokemon_1617796707"
+ },
+ {
+   "code": "Phantump",
+   "en": "Phantump",
+   "de": "Paragoni",
+   "fr": "Brocélôme",
+   "ja": "Bokurē ボクレー",
+   "ko": "Namokryeong 나목령",
+   "zh": "Xiǎomùlíng 小木灵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/phantump.png",
+   "obs_code": "pokemon_2671700398"
+ },
+ {
+   "code": "Trevenant",
+   "en": "Trevenant",
+   "de": "Trombork",
+   "fr": "Desséliande",
+   "ja": "Ōrotto オーロット",
+   "ko": "Daeroteu 대로트",
+   "zh": "Xiǔmùyāo 朽木妖",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/trevenant.png",
+   "obs_code": "pokemon_3064524352"
+ },
+ {
+   "code": "Pumpkaboo (Average Size)",
+   "en": "Pumpkaboo (Average Size)",
+   "de": "Irrbis",
+   "fr": "Pitrouille",
+   "ja": "Bakeccha バケッチャ",
+   "ko": "Hobagwi 호바귀",
+   "zh": "Nánguājīng 南瓜精",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pumpkaboo-average.png",
+   "obs_code": "pokemon_3668473787"
+ },
+ {
+   "code": "Gourgeist (Average Size)",
+   "en": "Gourgeist (Average Size)",
+   "de": "Pumpdjinn",
+   "fr": "Banshitrouye",
+   "ja": "Pampujin パンプジン",
+   "ko": "Peomkin'in 펌킨인",
+   "zh": "Nánguāguàirén 南瓜怪人",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gourgeist-average.png",
+   "obs_code": "pokemon_146342504"
+ },
+ {
+   "code": "Bergmite",
+   "en": "Bergmite",
+   "de": "Arktip",
+   "fr": "Grelaçon",
+   "ja": "Kachikōru カチコール",
+   "ko": "Kkong'eoreum 꽁어름",
+   "zh": "Bīngbǎo 冰宝",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bergmite.png",
+   "obs_code": "pokemon_588290370"
+ },
+ {
+   "code": "Avalugg",
+   "en": "Avalugg",
+   "de": "Arktilas",
+   "fr": "Séracrawl",
+   "ja": "Kurebēsu クレベース",
+   "ko": "Keurebeiseu 크레베이스",
+   "zh": "Bīngyánguài 冰岩怪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/avalugg.png",
+   "obs_code": "pokemon_2859141674"
+ },
+ {
+   "code": "Noibat",
+   "en": "Noibat",
+   "de": "eF-eM",
+   "fr": "Sonistrelle",
+   "ja": "Onbatto オンバット",
+   "ko": "Eumbaet 음뱃",
+   "zh": "Wēngfú 嗡蝠",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/noibat.png",
+   "obs_code": "pokemon_1742546490"
+ },
+ {
+   "code": "Noivern",
+   "en": "Noivern",
+   "de": "UHaFnir",
+   "fr": "Bruyverne",
+   "ja": "Onvern オンバーン",
+   "ko": "Eumbeon 음번",
+   "zh": "Yīnbōlóng 音波龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/noivern.png",
+   "obs_code": "pokemon_3586800930"
+ },
+ {
+   "code": "Xerneas",
+   "en": "Xerneas",
+   "de": "Xerneas",
+   "fr": "Xerneas",
+   "ja": "Xerneas ゼルネアス",
+   "ko": "Xerneas 제르네아스",
+   "zh": "Zhé'ěrníyǎsī 哲爾尼亞斯",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/xerneas.png",
+   "obs_code": "pokemon_2669564115"
+ },
+ {
+   "code": "Yveltal",
+   "en": "Yveltal",
+   "de": "Yveltal",
+   "fr": "Yveltal",
+   "ja": "Yveltal イベルタル",
+   "ko": "Yveltal 이벨타르",
+   "zh": "Yīpéi'ěrtǎ'ěr 伊裴爾塔爾",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/yveltal.png",
+   "obs_code": "pokemon_4238695610"
+ },
+ {
+   "code": "Zygarde (50% Forme)",
+   "en": "Zygarde (50% Forme)",
+   "de": "Zygarde",
+   "fr": "Zygarde",
+   "ja": "Zygarde ジガルデ",
+   "ko": "Jigareude 지가르데",
+   "zh": "Jīgéěrdé 基格尔德",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zygarde-50.png",
+   "obs_code": "pokemon_2440013563"
+ },
+ {
+   "code": "Diancie",
+   "en": "Diancie",
+   "de": "Diancie",
+   "fr": "Diancie",
+   "ja": "Diancie Diancie",
+   "ko": "Diancie 디안시",
+   "zh": "Dì'ānxī 蒂安希",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/diancie.png",
+   "obs_code": "pokemon_3927319176"
+ },
+ {
+   "code": "Hoopa (Hoopa Confined)",
+   "en": "Hoopa (Hoopa Confined)",
+   "de": "Hoopa",
+   "fr": "Hoopa",
+   "ja": "Hoopa フーパ",
+   "ko": "Hoopa 후파",
+   "zh": "Húbā 胡巴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hoopa-confined.png",
+   "obs_code": "pokemon_3639578611"
+ },
+ {
+   "code": "Volcanion",
+   "en": "Volcanion",
+   "de": "Volcanion",
+   "fr": "Volcanion",
+   "ja": "Volcanion ボルケニオン",
+   "ko": "Hoopa 볼케니온",
+   "zh": "Bōěrkǎiní'ēn 波尔凯尼恩",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/volcanion.png",
+   "obs_code": "pokemon_156610676"
+ },
+ {
+   "code": "Rowlet",
+   "en": "Rowlet",
+   "de": "Bauz",
+   "fr": "Brindibou",
+   "ja": "Mokuroh モクロー",
+   "ko": "Namolppaemi 나몰빼미",
+   "zh": "Muhkmuhkhīu 木木梟",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rowlet.png",
+   "obs_code": "pokemon_1747198706"
+ },
+ {
+   "code": "Dartrix",
+   "en": "Dartrix",
+   "de": "Arboretoss",
+   "fr": "Efflèche",
+   "ja": "フクスロー",
+   "ko": "Ppaemiseurou 빼미스로우",
+   "zh": "Tóuyǔxiāo 投羽梟",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dartrix.png",
+   "obs_code": "pokemon_3950278469"
+ },
+ {
+   "code": "Decidueye",
+   "en": "Decidueye",
+   "de": "Silvarro",
+   "fr": "Archéduc",
+   "ja": "Junaipā ジュナイパー",
+   "ko": "Mokeunaipeo 모크나이퍼",
+   "zh": "Jūshèshùxiāo 狙射樹梟",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/decidueye.png",
+   "obs_code": "pokemon_620048582"
+ },
+ {
+   "code": "Litten",
+   "en": "Litten",
+   "de": "Flamiau",
+   "fr": "Flamiaou",
+   "ja": "Nyabby ニャビー",
+   "ko": "Nyaobul 냐오불",
+   "zh": "Huǒbānmiāo 火斑喵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/litten.png",
+   "obs_code": "pokemon_1664614315"
+ },
+ {
+   "code": "Torracat",
+   "en": "Torracat",
+   "de": "Miezunder",
+   "fr": "Matoufeu",
+   "ja": "ニャヒート",
+   "ko": "Nyaohiteu 냐오히트",
+   "zh": "Yánrèmiāo 炎熱喵",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/torracat.png",
+   "obs_code": "pokemon_3499085833"
+ },
+ {
+   "code": "Incineroar",
+   "en": "Incineroar",
+   "de": "Fuegro",
+   "fr": "Félinferno",
+   "ja": "Gaogaen ガオガエン",
+   "ko": "Eoheungyeom 어흥염",
+   "zh": "Chìyànpáoxiàohǔ 熾焰咆哮虎",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/incineroar.png",
+   "obs_code": "pokemon_3577463213"
+ },
+ {
+   "code": "Popplio",
+   "en": "Popplio",
+   "de": "Robball",
+   "fr": "Otaquin",
+   "ja": "Ashimari アシマリ",
+   "ko": "Nuligong 누리공",
+   "zh": "Qiúqiúhǎishī 球球海獅",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/popplio.png",
+   "obs_code": "pokemon_4065870736"
+ },
+ {
+   "code": "Brionne",
+   "en": "Brionne",
+   "de": "Marikeck",
+   "fr": "Otarlette",
+   "ja": "オシャマリ",
+   "ko": "Kiyogong 키요공",
+   "zh": "Huāyànghǎishī 花漾海獅",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/brionne.png",
+   "obs_code": "pokemon_4036806774"
+ },
+ {
+   "code": "Primarina",
+   "en": "Primarina",
+   "de": "Primarene",
+   "fr": "Oratoria",
+   "ja": "アシレーヌ",
+   "ko": "Nurireneu 누리레느",
+   "zh": "Xīshīhǎirén 西獅海壬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/primarina.png",
+   "obs_code": "pokemon_1487865462"
+ },
+ {
+   "code": "Pikipek",
+   "en": "Pikipek",
+   "de": "Peppeck",
+   "fr": "Picassaut",
+   "ja": "ツツケラ",
+   "ko": "Kogkoguli 콕코구리",
+   "zh": "Xiǎodǔ'ér 小篤兒",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pikipek.png",
+   "obs_code": "pokemon_802283616"
+ },
+ {
+   "code": "Trumbeak",
+   "en": "Trumbeak",
+   "de": "Trompeck",
+   "fr": "Piclairon",
+   "ja": "Kerarappa ケララッパ",
+   "ko": "Keurapa 크라파",
+   "zh": "Lǎbāzhuóniǎo 喇叭啄鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/trumbeak.png",
+   "obs_code": "pokemon_537386678"
+ },
+ {
+   "code": "Toucannon",
+   "en": "Toucannon",
+   "de": "Tukanon",
+   "fr": "Bazoucan",
+   "ja": "Dodekabashi ドデカバシ",
+   "ko": "Wangkeunburi 왕큰부리",
+   "zh": "Chòngzuǐdàniǎo 銃嘴大鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/toucannon.png",
+   "obs_code": "pokemon_2528902440"
+ },
+ {
+   "code": "Yungoos",
+   "en": "Yungoos",
+   "de": "Mangunior",
+   "fr": "Manglouton",
+   "ja": "Yangūsu ヤングース",
+   "ko": "Yeong-guseu 영구스",
+   "zh": "Māoyòushào 貓鼬少",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/yungoos.png",
+   "obs_code": "pokemon_2905882035"
+ },
+ {
+   "code": "Gumshoos",
+   "en": "Gumshoos",
+   "de": "Manguspektor",
+   "fr": "Argouste",
+   "ja": "Dekagūsu デカグース",
+   "ko": "Hyeongsaguseu 형사구스",
+   "zh": "Māoyòutànzhǎng 貓鼬探長",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/gumshoos.png",
+   "obs_code": "pokemon_1426245586"
+ },
+ {
+   "code": "Grubbin",
+   "en": "Grubbin",
+   "de": "Mabula",
+   "fr": "Larvibule",
+   "ja": "Agojimushi アゴジムシ",
+   "ko": "Teokjichung-i 턱지충이",
+   "zh": "Qiáng'èjīmǔchóng 強顎雞母蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/grubbin.png",
+   "obs_code": "pokemon_2902235106"
+ },
+ {
+   "code": "Charjabug",
+   "en": "Charjabug",
+   "de": "Akkup",
+   "fr": "Chrysapile",
+   "ja": "Denjimushi デンヂムシ",
+   "ko": "jeonjichung-i 전지충이",
+   "zh": "Chóngdiànbǎo 蟲電寶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/charjabug.png",
+   "obs_code": "pokemon_2604043654"
+ },
+ {
+   "code": "Vikavolt",
+   "en": "Vikavolt",
+   "de": "Donarion",
+   "fr": "Lucanon",
+   "ja": "Kuwaganon クワガノン",
+   "ko": "Tuguppul 투구뿌논",
+   "zh": "Qiāonóngpàochóng 鍬農炮蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/vikavolt.png",
+   "obs_code": "pokemon_192725425"
+ },
+ {
+   "code": "Crabrawler",
+   "en": "Crabrawler",
+   "de": "Krabbox",
+   "fr": "Crabagarre",
+   "ja": "マケンカニ",
+   "ko": "Ogijige 오기지게",
+   "zh": "Hàoshèngxiè 好勝蟹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/crabrawler.png",
+   "obs_code": "pokemon_1765735528"
+ },
+ {
+   "code": "Crabominable",
+   "en": "Crabominable",
+   "de": "Krawell",
+   "fr": "Crabominable",
+   "ja": "Kekenkani ケケンカニ",
+   "ko": "Modandange 모단단게",
+   "zh": "Hàoshèngmáoxiè 好勝毛蟹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/crabominable.png",
+   "obs_code": "pokemon_142483096"
+ },
+ {
+   "code": "Oricorio (Baile Style)",
+   "en": "Oricorio (Baile Style)",
+   "de": "Choreogel",
+   "fr": "Plumeline",
+   "ja": "Odoridori オドリドリ",
+   "ko": "Chumchuse 춤추새",
+   "zh": "Huāwǔniǎo 花舞鳥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/oricorio-baile.png",
+   "obs_code": "pokemon_639771015"
+ },
+ {
+   "code": "Cutiefly",
+   "en": "Cutiefly",
+   "de": "Wommel",
+   "fr": "Bombydou",
+   "ja": "Aburī アブリー",
+   "ko": "Ebeulli 에블리",
+   "zh": "Méngméng 萌虻",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cutiefly.png",
+   "obs_code": "pokemon_1643970808"
+ },
+ {
+   "code": "Ribombee",
+   "en": "Ribombee",
+   "de": "Bandelby",
+   "fr": "Rubombelle",
+   "ja": "アブリボン",
+   "ko": "Eribon 에리본",
+   "zh": "Diéjiéméngméng 蝶結萌虻",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/ribombee.png",
+   "obs_code": "pokemon_156385084"
+ },
+ {
+   "code": "Rockruff",
+   "en": "Rockruff",
+   "de": "Wuffels",
+   "fr": "Rocabot",
+   "ja": "Iwanko イワンコ",
+   "ko": "Ammeong-i 암멍이",
+   "zh": "Yángǒugǒu 岩狗狗",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/rockruff.png",
+   "obs_code": "pokemon_2755621815"
+ },
+ {
+   "code": "Lycanroc (Midday Form)",
+   "en": "Lycanroc (Midday Form)",
+   "de": "Wolwerock",
+   "fr": "Lougaroc",
+   "ja": "ルガルガン",
+   "ko": "",
+   "zh": "Zōngyánlángrén 鬃岩狼人",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lycanroc-midday.png",
+   "obs_code": "pokemon_3297914867"
+ },
+ {
+   "code": "Wishiwashi (Solo Form)",
+   "en": "Wishiwashi (Solo Form)",
+   "de": "Lusardin",
+   "fr": "Froussardine",
+   "ja": "Yowashi ヨワシ",
+   "ko": "Yageori 약어리",
+   "zh": "Dāndú-de Yàngzi 單獨的樣子",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wishiwashi-solo.png",
+   "obs_code": "pokemon_3960784895"
+ },
+ {
+   "code": "Mareanie",
+   "en": "Mareanie",
+   "de": "Garstella",
+   "fr": "Vorastérie",
+   "ja": "Hidoide ヒドイデ",
+   "ko": "Simasari 시마사리",
+   "zh": "Hǎohuàixīng 好壞星",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mareanie.png",
+   "obs_code": "pokemon_866228605"
+ },
+ {
+   "code": "Toxapex",
+   "en": "Toxapex",
+   "de": "Aggrostella",
+   "fr": "Prédastérie",
+   "ja": "Dohidoide ドヒドイデ",
+   "ko": "Deosimasari 더시마사리",
+   "zh": "Chāohuàixīng 超壞星",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/toxapex.png",
+   "obs_code": "pokemon_4099411882"
+ },
+ {
+   "code": "Mudbray",
+   "en": "Mudbray",
+   "de": "Pampuli",
+   "fr": "Tiboudet",
+   "ja": "Dorobanko ドロバンコ",
+   "ko": "Meodeunagi 머드나기",
+   "zh": "Nílǘzǐ 泥驢仔",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mudbray.png",
+   "obs_code": "pokemon_1109883281"
+ },
+ {
+   "code": "Mudsdale",
+   "en": "Mudsdale",
+   "de": "Pampross",
+   "fr": "Bourrinos",
+   "ja": "Banbadoro バンバドロ",
+   "ko": "Manmadeu 만마드",
+   "zh": "Zhòngníwǎnmǎ 重泥挽馬",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mudsdale.png",
+   "obs_code": "pokemon_2837263046"
+ },
+ {
+   "code": "Dewpider",
+   "en": "Dewpider",
+   "de": "Araqua",
+   "fr": "Araqua",
+   "ja": "Shizukumo シズクモ",
+   "ko": "Mulgeomi 물거미",
+   "zh": "Dīzhū 滴蛛",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dewpider.png",
+   "obs_code": "pokemon_2871427769"
+ },
+ {
+   "code": "Araquanid",
+   "en": "Araquanid",
+   "de": "Aranestro",
+   "fr": "Tarenbulle",
+   "ja": "Onishikuzumo オニシズクモ",
+   "ko": "Kkaebimulgeomi 깨비물거미",
+   "zh": "Dīzhūbà 滴蛛霸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/araquanid.png",
+   "obs_code": "pokemon_552100337"
+ },
+ {
+   "code": "Fomantis",
+   "en": "Fomantis",
+   "de": "Imantis",
+   "fr": "Mimantis",
+   "ja": "Karikiri カリキリ",
+   "ko": "Jjalanglang 짜랑랑",
+   "zh": "Wèitángcǎo 偽螳草",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/fomantis.png",
+   "obs_code": "pokemon_3560106464"
+ },
+ {
+   "code": "Lurantis",
+   "en": "Lurantis",
+   "de": "Mantidea",
+   "fr": "Floramantis",
+   "ja": "Rarantesu ラランテス",
+   "ko": "Lalantiseu 라란티스",
+   "zh": "Lántánghuā 蘭螳花",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lurantis.png",
+   "obs_code": "pokemon_3560117999"
+ },
+ {
+   "code": "Morelull",
+   "en": "Morelull",
+   "de": "Bubungus",
+   "fr": "Spododo",
+   "ja": "ネマシュ",
+   "ko": "Jamasyu 자마슈",
+   "zh": "Shuìshuìgū 睡睡菇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/morelull.png",
+   "obs_code": "pokemon_103247209"
+ },
+ {
+   "code": "Shiinotic",
+   "en": "Shiinotic",
+   "de": "Lamellux",
+   "fr": "Lampignon",
+   "ja": "Mashēdo マシェード",
+   "ko": "Masyeideu 마셰이드",
+   "zh": "Dēngzhàoyègū 燈罩夜菇",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/shiinotic.png",
+   "obs_code": "pokemon_2730853985"
+ },
+ {
+   "code": "Salandit",
+   "en": "Salandit",
+   "de": "Molunk",
+   "fr": "Tritox",
+   "ja": "Yatōmori ヤトウモリ",
+   "ko": "Yadonyong 야도뇽",
+   "zh": "Yèdàohuǒxī 夜盜火蜥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/salandit.png",
+   "obs_code": "pokemon_901464589"
+ },
+ {
+   "code": "Salazzle",
+   "en": "Salazzle",
+   "de": "Amfira",
+   "fr": "Malamandre",
+   "ja": "Ennyūto エンニュート",
+   "ko": "Yeomnyuteu 염뉴트",
+   "zh": "Yànhòuxī 焰后蜥",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/salazzle.png",
+   "obs_code": "pokemon_3404797299"
+ },
+ {
+   "code": "Stufful",
+   "en": "Stufful",
+   "de": "Velursi",
+   "fr": "Nounourson",
+   "ja": "Nuikoguma ヌイコグマ",
+   "ko": "Pogomgom 포곰곰",
+   "zh": "Tóng'ǒuxióng 童偶熊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stufful.png",
+   "obs_code": "pokemon_705280430"
+ },
+ {
+   "code": "Bewear",
+   "en": "Bewear",
+   "de": "Kosturso",
+   "fr": "Chelours",
+   "ja": "Kiteruguma キテルグマ",
+   "ko": "Ibeun-gom 이븐곰",
+   "zh": "Chuānzhuóxióng 穿著熊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bewear.png",
+   "obs_code": "pokemon_2128881283"
+ },
+ {
+   "code": "Bounsweet",
+   "en": "Bounsweet",
+   "de": "Frubberl",
+   "fr": "Croquine",
+   "ja": "Amakaji アマカジ",
+   "ko": "Dalkom-a 달콤아",
+   "zh": "Tiánzhúzhú 甜竹竹",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bounsweet.png",
+   "obs_code": "pokemon_3823337635"
+ },
+ {
+   "code": "Steenee",
+   "en": "Steenee",
+   "de": "Frubaila",
+   "fr": "Candine",
+   "ja": "アママイコ",
+   "ko": "Dalmurina 달무리나",
+   "zh": "Tiánwǔní 甜舞妮",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/steenee.png",
+   "obs_code": "pokemon_3783854924"
+ },
+ {
+   "code": "Tsareena",
+   "en": "Tsareena",
+   "de": "Fruyal",
+   "fr": "Sucreine",
+   "ja": "アマージョ",
+   "ko": "Dalkokwin 달코퀸",
+   "zh": "Tiánlěngměihòu 甜冷美后",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tsareena.png",
+   "obs_code": "pokemon_1791977662"
+ },
+ {
+   "code": "Comfey",
+   "en": "Comfey",
+   "de": "Curelei",
+   "fr": "Guérilande",
+   "ja": "Kyuwawā キュワワー",
+   "ko": "Kyuaring 큐아링",
+   "zh": "Huāliáohuánhuán 花療環環",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/comfey.png",
+   "obs_code": "pokemon_2242152990"
+ },
+ {
+   "code": "Oranguru",
+   "en": "Oranguru",
+   "de": "Kommandutan",
+   "fr": "Gouroutan",
+   "ja": "ヤレユータン",
+   "ko": "Harang-utan 하랑우탄",
+   "zh": "Zhìhuīxīng 智揮猩",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/oranguru.png",
+   "obs_code": "pokemon_2681027970"
+ },
+ {
+   "code": "Passimian",
+   "en": "Passimian",
+   "de": "Quartermak",
+   "fr": "Quartermac",
+   "ja": "ナゲツケサル",
+   "ko": "Naedeonsung-i 내던숭이",
+   "zh": "Tóuzhíhóu 投擲猴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/passimian.png",
+   "obs_code": "pokemon_1662836502"
+ },
+ {
+   "code": "Wimpod",
+   "en": "Wimpod",
+   "de": "Reißlaus",
+   "fr": "Sovkipou",
+   "ja": "Kosokumushi コソクムシ",
+   "ko": "Kkosire 꼬시레",
+   "zh": "Dǎnxiǎchóng 膽小蟲",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/wimpod.png",
+   "obs_code": "pokemon_1128721325"
+ },
+ {
+   "code": "Golisopod",
+   "en": "Golisopod",
+   "de": "Tectass",
+   "fr": "Sarmuraï",
+   "ja": "Gusokumusha グソクムシャ",
+   "ko": "Gapjumusa 갑주무사",
+   "zh": "Jùjiǎwǔzhě 具甲武者",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/golisopod.png",
+   "obs_code": "pokemon_1239904399"
+ },
+ {
+   "code": "Sandygast",
+   "en": "Sandygast",
+   "de": "Sankabuh",
+   "fr": "Bacabouh",
+   "ja": "スナバア",
+   "ko": "Moraekkung 모래꿍",
+   "zh": "Shāqiūwá 沙丘娃",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/sandygast.png",
+   "obs_code": "pokemon_301241381"
+ },
+ {
+   "code": "Palossand",
+   "en": "Palossand",
+   "de": "Colossand",
+   "fr": "Trépassable",
+   "ja": "シロデスナ",
+   "ko": "Moraeseong-idang 모래성이당",
+   "zh": "Shìshābǎoyé 噬沙堡爺",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/palossand.png",
+   "obs_code": "pokemon_2895931644"
+ },
+ {
+   "code": "Pyukumuku",
+   "en": "Pyukumuku",
+   "de": "Gufa",
+   "fr": "Concombaffe",
+   "ja": "Namakobushi ナマコブシ",
+   "ko": "Haemugi 해무기",
+   "zh": "Quánhǎishēn 拳海參",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pyukumuku.png",
+   "obs_code": "pokemon_1267705793"
+ },
+ {
+   "code": "Type: Null",
+   "en": "Type: Null",
+   "de": "Typ:Null",
+   "fr": "Type:0",
+   "ja": "タイプ:ヌル",
+   "ko": "Type: Null 타입:널",
+   "zh": "Shǔxìng: Kōng 屬性：空",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/type-null.png",
+   "obs_code": "pokemon_3405451083"
+ },
+ {
+   "code": "Silvally",
+   "en": "Silvally",
+   "de": "Amigento",
+   "fr": "Silvallié",
+   "ja": "シルヴァディ",
+   "ko": "실버디",
+   "zh": "銀伴戰獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/silvally.png",
+   "obs_code": "pokemon_1731047965"
+ },
+ {
+   "code": "Minior (Meteor Form)",
+   "en": "Minior (Meteor Form)",
+   "de": "Meteno",
+   "fr": "Météno",
+   "ja": "Meteno メテノ",
+   "ko": "Mete-o 메테노",
+   "zh": "Xiǎoyǔnxīng 小隕星",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/minior-meteor.png",
+   "obs_code": "pokemon_276589970"
+ },
+ {
+   "code": "Komala",
+   "en": "Komala",
+   "de": "Koalelu",
+   "fr": "Dodoala",
+   "ja": "Nekkoara ネッコアラ",
+   "ko": "Jamilla 자말라",
+   "zh": "Shùzhěnwěixióng 樹枕尾熊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/komala.png",
+   "obs_code": "pokemon_1313126944"
+ },
+ {
+   "code": "Turtonator",
+   "en": "Turtonator",
+   "de": "Tortunator",
+   "fr": "Boumata",
+   "ja": "バクガメス",
+   "ko": "Pokgeobukseu 폭거북스",
+   "zh": "Bàoyànguīshòu 爆焰龜獸",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/turtonator.png",
+   "obs_code": "pokemon_1468679275"
+ },
+ {
+   "code": "Togedemaru",
+   "en": "Togedemaru",
+   "de": "Togedemaru",
+   "fr": "Togedemaru",
+   "ja": "Togedemaru トゲデマル",
+   "ko": "Togedemalu 토게데마루",
+   "zh": "Tuōgēdémǎ'ěr 托戈德瑪爾",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/togedemaru.png",
+   "obs_code": "pokemon_1860892662"
+ },
+ {
+   "code": "Mimikyu",
+   "en": "Mimikyu",
+   "de": "Mimigma",
+   "fr": "Mimiqui",
+   "ja": "Mimikkyu ミミッキュ",
+   "ko": "Ttarakyu 따라큐",
+   "zh": "Mínǐ-Q 謎擬Ｑ",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/mimikyu.png",
+   "obs_code": "pokemon_2480636002"
+ },
+ {
+   "code": "Bruxish",
+   "en": "Bruxish",
+   "de": "Knirfish",
+   "fr": "Denticrisse",
+   "ja": "Hagigishiri ハギギシリ",
+   "ko": "Chibalgi 치갈기",
+   "zh": "Móyácǎipíyú 磨牙彩皮魚",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/bruxish.png",
+   "obs_code": "pokemon_1342156778"
+ },
+ {
+   "code": "Drampa",
+   "en": "Drampa",
+   "de": "Sen-Long",
+   "fr": "Draïeul",
+   "ja": "Jijiron ジジーロン",
+   "ko": "Halbilong 할비롱",
+   "zh": "Lǎowēnglóng 老翁龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/drampa.png",
+   "obs_code": "pokemon_1327505486"
+ },
+ {
+   "code": "Dhelmise",
+   "en": "Dhelmise",
+   "de": "Moruda",
+   "fr": "Sinistrail",
+   "ja": "Dadarin ダダリン",
+   "ko": "Tataryun 타타륜",
+   "zh": "Pòpòduòlún 破破舵輪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/dhelmise.png",
+   "obs_code": "pokemon_1884562770"
+ },
+ {
+   "code": "Jangmo-o",
+   "en": "Jangmo-o",
+   "de": "Miniras",
+   "fr": "Bébécaille",
+   "ja": "ジャラコ",
+   "ko": "Jjarangkko 짜랑꼬",
+   "zh": "Xīnlínbǎo 心鱗寶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/jangmo-o.png",
+   "obs_code": "pokemon_887519559"
+ },
+ {
+   "code": "Hakamo-o",
+   "en": "Hakamo-o",
+   "de": "Mediras",
+   "fr": "Écaïd",
+   "ja": "ジャランゴ",
+   "ko": "짜랑고우",
+   "zh": "鱗甲龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/hakamo-o.png",
+   "obs_code": "pokemon_887459398"
+ },
+ {
+   "code": "Kommo-o",
+   "en": "Kommo-o",
+   "de": "Grandiras",
+   "fr": "Ékaïser",
+   "ja": "ジャラランガ",
+   "ko": "짜랑고우거",
+   "zh": "杖尾鱗甲龍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kommo-o.png",
+   "obs_code": "pokemon_1849004012"
+ },
+ {
+   "code": "Tapu Koko",
+   "en": "Tapu Koko",
+   "de": "Kapu-Riki",
+   "fr": "Tokorico",
+   "ja": "Kapu Kokeko カプ・コケコ",
+   "ko": "Kapukkokkokkog 카푸꼬꼬꼭",
+   "zh": "Kǎpú Míngmín 卡璞・鳴鳴",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tapu-koko.png",
+   "obs_code": "pokemon_211230168"
+ },
+ {
+   "code": "Tapu Lele",
+   "en": "Tapu Lele",
+   "de": "Kapu-Fala",
+   "fr": "Tokopiyon",
+   "ja": "カプ・テテフ",
+   "ko": "Kapunabina 카푸나비나",
+   "zh": "Kǎpú Diédié 卡璞・蝶蝶",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tapu-lele.png",
+   "obs_code": "pokemon_2472646936"
+ },
+ {
+   "code": "Tapu Bulu",
+   "en": "Tapu Bulu",
+   "de": "Kapu-Toro",
+   "fr": "Tokotoro",
+   "ja": "カプ・ブルル",
+   "ko": "Kapubeururu 카푸브루루",
+   "zh": "Kǎpú Mōumōu 卡璞・哞哞",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tapu-bulu.png",
+   "obs_code": "pokemon_418154966"
+ },
+ {
+   "code": "Tapu Fini",
+   "en": "Tapu Fini",
+   "de": "Kapu-Kime",
+   "fr": "Tokopisco",
+   "ja": "カプ・レヒレ",
+   "ko": "Kapuneujineu 카푸느지느",
+   "zh": "Kǎpú Qíqí 卡璞・鰭鰭",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/tapu-fini.png",
+   "obs_code": "pokemon_3876093456"
+ },
+ {
+   "code": "Cosmog",
+   "en": "Cosmog",
+   "de": "Cosmog",
+   "fr": "Cosmog",
+   "ja": "コスモッグ",
+   "ko": "Koseumogeu 코스모그",
+   "zh": "Kēsīmògǔ 科斯莫古",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cosmog.png",
+   "obs_code": "pokemon_1396772351"
+ },
+ {
+   "code": "Cosmoem",
+   "en": "Cosmoem",
+   "de": "Cosmovum",
+   "fr": "Cosmovum",
+   "ja": "Kosumōmu コスモウム",
+   "ko": "Koseumoum 코스모움",
+   "zh": "Kēsīmòmǔ 科斯莫姆",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/cosmoem.png",
+   "obs_code": "pokemon_1203874736"
+ },
+ {
+   "code": "Solgaleo",
+   "en": "Solgaleo",
+   "de": "Solgaleo",
+   "fr": "Solgaleo",
+   "ja": "Sorugareo ソルガレオ",
+   "ko": "Solgaleo 솔가레오",
+   "zh": "Suǒ'ěrjiāléi'ōu 索爾迦雷歐",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/solgaleo.png",
+   "obs_code": "pokemon_2685849845"
+ },
+ {
+   "code": "Lunala",
+   "en": "Lunala",
+   "de": "Lunala",
+   "fr": "Lunala",
+   "ja": "Runaāra ルナアーラ",
+   "ko": "Lunaala 루나아라",
+   "zh": "Lùnàiyǎlā 露奈雅拉",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/lunala.png",
+   "obs_code": "pokemon_1313124030"
+ },
+ {
+   "code": "Nihilego",
+   "en": "Nihilego",
+   "de": "Anego",
+   "fr": "Zéroïd",
+   "ja": "Utsuroido ウツロイド",
+   "ko": "Teongbideu 텅비드",
+   "zh": "Xūwúyīdé 虛吾伊德",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/nihilego.png",
+   "obs_code": "pokemon_862683906"
+ },
+ {
+   "code": "Buzzwole",
+   "en": "Buzzwole",
+   "de": "Masskito",
+   "fr": "Mouscoto",
+   "ja": "Masshibun マッシブーン",
+   "ko": "Maesibung 매시붕",
+   "zh": "Bàojīwén 爆肌蚊",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/buzzwole.png",
+   "obs_code": "pokemon_2619280099"
+ },
+ {
+   "code": "Pheromosa",
+   "en": "Pheromosa",
+   "de": "Schabelle",
+   "fr": "Cancrelove",
+   "ja": "Ferōche フェローチェ",
+   "ko": "Perokoche 페로코체",
+   "zh": "Fèiluòměiláng 費洛美螂 / 费洛美螂",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/pheromosa.png",
+   "obs_code": "pokemon_1417644309"
+ },
+ {
+   "code": "Xurkitree",
+   "en": "Xurkitree",
+   "de": "Voltriant",
+   "fr": "Câblifère",
+   "ja": "Denjumoko デンジュモク",
+   "ko": "Jeonsumok 전수목",
+   "zh": "Diànshùmù 電束木",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/xurkitree.png",
+   "obs_code": "pokemon_3387334270"
+ },
+ {
+   "code": "Celesteela",
+   "en": "Celesteela",
+   "de": "Kaguron",
+   "fr": "Bamboiselle",
+   "ja": "Tekkaguya テッカグヤ",
+   "ko": "Cheolhwaguya 철화구야",
+   "zh": "Tiěhuǒhuīyè 鐵火輝夜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/celesteela.png",
+   "obs_code": "pokemon_3268203520"
+ },
+ {
+   "code": "Kartana",
+   "en": "Kartana",
+   "de": "Katagami",
+   "fr": "Katagami",
+   "ja": "Kamitsurugi カミツルギ",
+   "ko": "Jong-isindo 종이신도",
+   "zh": "Zhǐyùjiàn 紙御劍",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/kartana.png",
+   "obs_code": "pokemon_310653607"
+ },
+ {
+   "code": "Guzzlord",
+   "en": "Guzzlord",
+   "de": "Schlingking",
+   "fr": "Engloutyran",
+   "ja": "Akujikingu アクジキング",
+   "ko": "Aksikking 악식킹",
+   "zh": "Èshídàwáng 惡食大王",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/guzzlord.png",
+   "obs_code": "pokemon_426700930"
+ },
+ {
+   "code": "Necrozma",
+   "en": "Necrozma",
+   "de": "Necrozma",
+   "fr": "Necrozma",
+   "ja": "Necrozma ネクロズマ",
+   "ko": "Necrozma 네크로즈마",
+   "zh": "Nàikèluòzīmǎ 奈克洛茲瑪",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/necrozma.png",
+   "obs_code": "pokemon_3441775942"
+ },
+ {
+   "code": "Magearna",
+   "en": "Magearna",
+   "de": "Magearna",
+   "fr": "Magearna",
+   "ja": "Magearna マギアナ",
+   "ko": "Magiana 마기아나",
+   "zh": "Mǎjīyǎnà 瑪機雅娜",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/magearna.png",
+   "obs_code": "pokemon_2383072055"
+ },
+ {
+   "code": "Marshadow",
+   "en": "Marshadow",
+   "de": "Marshadow",
+   "fr": "Marshadow",
+   "ja": "Marshadow マーシャドー",
+   "ko": "Marshadow 마샤도",
+   "zh": "Mǎxiàduō 瑪夏多",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/marshadow.png",
+   "obs_code": "pokemon_2883291485"
+ },
+ {
+   "code": "Poipole",
+   "en": "Poipole",
+   "de": "Venicro",
+   "fr": "Vémini",
+   "ja": "Bebenomu ベベノム",
+   "ko": "Bebenom 베베놈",
+   "zh": "Dúbèibǐ 毒贝比",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/poipole.png",
+   "obs_code": "pokemon_4114092261"
+ },
+ {
+   "code": "Naganadel",
+   "en": "Naganadel",
+   "de": "Agoyon",
+   "fr": "",
+   "ja": "",
+   "ko": "",
+   "zh": "",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/naganadel.png",
+   "obs_code": "pokemon_1312245902"
+ },
+ {
+   "code": "Stakataka",
+   "en": "Stakataka",
+   "de": "Muramura",
+   "fr": "Ama-Ama",
+   "ja": "Tsundetsunde ツンデツンデ",
+   "ko": "Chagogchagog 차곡차곡",
+   "zh": "Lěilěishí 垒磊石",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/stakataka.png",
+   "obs_code": "pokemon_2852879830"
+ },
+ {
+   "code": "Blacephalon",
+   "en": "Blacephalon",
+   "de": "Kopplosio",
+   "fr": "Pierroteknik",
+   "ja": "Zugadōn ズガドーン",
+   "ko": "Dupapang 두파팡",
+   "zh": "Pēngtóuxiǎochǒu 砰頭小丑",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/blacephalon.png",
+   "obs_code": "pokemon_4144409272"
+ },
+ {
+   "code": "Zeraora",
+   "en": "Zeraora",
+   "de": "Zeraora",
+   "fr": "Zeraora",
+   "ja": "Zeraora ゼラオラ",
+   "ko": "Jeraora 제라오라",
+   "zh": "",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/zeraora.png",
+   "obs_code": "pokemon_786565397"
+ },
+ {
+   "code": "Meltan",
+   "en": "Meltan",
+   "de": "Meltan",
+   "fr": "Meltan",
+   "ja": "メルタン",
+   "ko": "Meltan 멜탄",
+   "zh": "Měilùtǎn 美錄坦",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/meltan.png",
+   "obs_code": "pokemon_1660158522"
+ },
+ {
+   "code": "Melmetal",
+   "en": "Melmetal",
+   "de": "Melmetal",
+   "fr": "Melmetal",
+   "ja": "メルメタル",
+   "ko": "Melmetal 멜메탈",
+   "zh": "Měilùméitǎ 美錄梅塔",
+   "url": "https://img.pokemondb.net/sprites/sun-moon/icon/melmetal.png",
+   "obs_code": "pokemon_2445901584"
+ }
 ]

--- a/src/mutation-constants.js
+++ b/src/mutation-constants.js
@@ -6,6 +6,7 @@
 // can use to compose in differnt ways.
 
 
+export const SET_LANGUAGE = 'SET_LANGUAGE';
 export const SET_GAME_MODE = 'SET_GAME_MODE';
 export const GET_RANDOM_FLAG = 'GET_RANDOM_FLAG';
 export const GET_GUESSING_OPTIONS = 'GET_GUESSING_OPTIONS';

--- a/src/store.js
+++ b/src/store.js
@@ -77,7 +77,7 @@ export default new Vuex.Store({
       const s = initialState()
 
       Object.keys(s).forEach(key => {
-          state[key] = s[key]
+        state[key] = s[key]
       })
       state.currentLanguage = tmp;
     },

--- a/src/store.js
+++ b/src/store.js
@@ -6,6 +6,7 @@ import flags from './constants/flags';
 // Mutation constants
 import {
   GUESS_FLAG,
+  SET_LANGUAGE,
   SET_GAME_MODE,
   GET_RANDOM_FLAG,
   GET_GUESSING_OPTIONS,
@@ -29,6 +30,7 @@ function initialState () {
     currentOptions: [],
     justGuessed: false,
     currentGuess: '',
+    currentLanguage: 'en',
   }
 }
 
@@ -41,6 +43,10 @@ export default new Vuex.Store({
   actions: {
     setScoreInitial({ commit }) {
       commit(RESET_STATE_DATA);
+    },
+    // Set the language
+    setLanguage({ commit }, language) {
+      commit(SET_LANGUAGE, language);
     },
     // Set the game mode
     setGameMode({ commit }, mode) {
@@ -67,11 +73,13 @@ export default new Vuex.Store({
   // Mutations
   mutations: {
     [RESET_STATE_DATA](state) {
+      const tmp = state.currentLanguage;
       const s = initialState()
 
       Object.keys(s).forEach(key => {
-        state[key] = s[key]
+          state[key] = s[key]
       })
+      state.currentLanguage = tmp;
     },
     [GET_RANDOM_FLAG](state) {
       const randomFlagIndex = Math.floor(Math.random() * (state.flags.length - 1));
@@ -113,6 +121,10 @@ export default new Vuex.Store({
     [SET_GAME_MODE](state, mode) {
       // Increase total
       state.currentGameMode = mode;
+    },
+    [SET_LANGUAGE](state, language) {
+      // Increase total
+      state.currentLanguage = language;
     },
   },
 });

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,16 +3,19 @@
     <img src="../assets/loading.gif" alt="TW Icon Game" />
     <h2 class="md-display-6">Pokemon Master</h2>
     <select-game-type />
+    <select-language />
   </div>
 </template>
 
 <script>
 import SelectGameType from '@/components/SelectGameType.vue';
+import SelectLanguage from '@/components/SelectLanguage.vue';
 
 export default {
   name: 'App',
   components: {
     SelectGameType,
+    SelectLanguage
   },
 };
 </script>


### PR DESCRIPTION
I've added a language picker for the Pokémon names and added five new languages based on [this list](https://pokefans.net/pokedex/pokemon-liste/internationale-namen), so players who played the original games in other languages can try this game too.

[This](https://github.com/WeiChiaChang/pokemon-master/compare/master...danielstieber:master#diff-3bf35cd41da51153dcca3003656f7c67R76) is probably not the smoothest solution, but I needed to save the current location during the state reset, to prevent resetting the language when starting/ending a game.

[Demo](https://stieber.uber.space/pokemon-master/dist/#)